### PR TITLE
Documentation adjustments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab
+indent_size = 8
+
+[*.hs]
+indent_size = 4
+max_line_length = 80

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,16 @@ jobs:
     - name: Setup Stack
       uses: mstksg/setup-stack@v1
 
+    - name: Cache Key
+      id: cache_key
+      run: echo ::set-output name=key::$(md5sum stack.yaml | awk '{print $1}')
+
     - name: Cache Dependencies
       id: cache
       uses: actions/cache@v1
       with:
         path: ~/.stack
-        key: ${{ matrix.os }}-stack
+        key: ${{ matrix.os }}-${{ steps.cache_key.outputs.key }}
 
     - name: Build Snapshot
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,83 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+- modules:
+  # Enforce some common qualified imports aliases across the codebase
+  - {name: [Data.Aeson, Data.Aeson.Types], as: Aeson}
+  - {name: [Data.ByteArray], as: BA}
+  - {name: [Data.ByteString.Base16], as: B16}
+  - {name: [Data.ByteString.Char8], as: B8}
+  - {name: [Data.ByteString.Lazy], as: BL}
+  - {name: [Data.ByteString], as: BS}
+  - {name: [Data.Foldable], as: F}
+  - {name: [Data.List.NonEmpty], as: NE}
+  - {name: [Data.List], as: L}
+  - {name: [Data.Map.Strict], as: Map}
+  - {name: [Data.Sequence], as: Seq}
+  - {name: [Data.Set, Data.HashSet], as: Set}
+  - {name: [Data.Text, Data.Text.Encoding], as: T}
+  - {name: [Data.Vector], as: V}
+
+# Ignore some build-in rules
+- ignore: {name: "Reduce duplication"} # This is a decision left to developers and reviewers
+- ignore: {name: "Redundant bracket"} # Not everyone knows precedences of every operators in Haskell. Brackets help readability.
+- ignore: {name: "Redundant do"} # Just an annoying hlint built-in, GHC may remove redundant do if he wants
+- ignore: {name: "Monoid law, left identity"} # Using 'mempty' can be useful to vertically-align elements
+- ignore: {name: "Use ?~"} # It's actually much clearer to do (.~ Just ...) than having to load yet-another-lens-operator
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,22 @@
+# Stylish-haskell configuration file
+#
+# See `stylish-haskell --defaults` or
+# https://github.com/jaspervdj/stylish-haskell/blob/master/data/stylish-haskell.yaml
+# for usage.
+
+columns: 80 # Should match .editorconfig
+steps:
+  - imports:
+      align: none
+      empty_list_align: inherit
+      list_align: new_line
+      list_padding: 4
+      long_list_align: new_line_multiline
+      pad_module_names: false
+      separate_lists: true
+      space_surround: true
+
+  - language_pragmas:
+      align: false
+      remove_redundant: true
+      style: vertical

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-crypto
-    commit: 05aa1bc640c42bfca787531d12595489c1fa3b82
+    commit: 2547ad1e80aeabca2899951601079408becbc92c

--- a/test/Cardano/MnemonicSpec.hs
+++ b/test/Cardano/MnemonicSpec.hs
@@ -19,10 +19,9 @@ import Cardano.Mnemonic
     ( Entropy
     , EntropyError
     , EntropySize
-    , FromMnemonic (..)
-    , FromMnemonicError (..)
+    , MkMnemonicError (..)
+    , MkSomeMnemonicError (..)
     , Mnemonic
-    , MnemonicError (..)
     , MnemonicException (..)
     , MnemonicWords
     , entropyToBytes
@@ -30,6 +29,7 @@ import Cardano.Mnemonic
     , genEntropy
     , mkEntropy
     , mkMnemonic
+    , mkSomeMnemonic
     , mnemonicToEntropy
     , mnemonicToText
     )
@@ -125,63 +125,63 @@ spec = do
     prop "(24) mkMnemonic . mnemonicToText == pure" $
         \(mw :: Mnemonic 24) -> (mkMnemonic @24 . mnemonicToText) mw === pure mw
 
-    describe "FromMnemonic" $ do
+    describe "MkSomeMnemonic" $ do
         let noInDictErr =
                 "Found an unknown word not present in the pre-defined dictionary. \
                 \The full dictionary is available here: https://github.com/input\
                 \-output-hk/cardano-wallet/tree/master/specifications/mnemonic/english.txt"
 
         it "early error reported first (Invalid Entropy)" $ do
-            let res = fromMnemonic @'[15,18,21]
+            let res = mkSomeMnemonic @'[15,18,21]
                         [ "glimpse", "paper", "toward", "fine", "alert"
                         , "baby", "pyramid", "alone", "shaft", "force"
                         , "circle", "fancy", "squeeze", "cannon", "toilet"
                         ]
-            res `shouldBe` Left (FromMnemonicError "Invalid entropy checksum: \
+            res `shouldBe` Left (MkSomeMnemonicError "Invalid entropy checksum: \
                 \please double-check the last word of your mnemonic sentence.")
 
         it "early error reported first (Non-English Word)" $ do
-            let res = fromMnemonic @'[15,18,21]
+            let res = mkSomeMnemonic @'[15,18,21]
                         [ "baguette", "paper", "toward", "fine", "alert"
                         , "baby", "pyramid", "alone", "shaft", "force"
                         , "circle", "fancy", "squeeze", "cannon", "toilet"
                         ]
-            res `shouldBe` Left (FromMnemonicError noInDictErr)
+            res `shouldBe` Left (MkSomeMnemonicError noInDictErr)
 
         it "early error reported first (Wrong number of words - 1)" $ do
-            let res = fromMnemonic @'[15,18,21]
+            let res = mkSomeMnemonic @'[15,18,21]
                         ["mom", "unveil", "slim", "abandon"
                         , "nut", "cash", "laugh", "impact"
                         , "system", "split", "depth", "sun"
                         ]
-            res `shouldBe` Left (FromMnemonicError "Invalid number of words: \
+            res `shouldBe` Left (MkSomeMnemonicError "Invalid number of words: \
                 \15, 18 or 21 words are expected.")
 
         it "early error reported first (Wrong number of words - 2)" $ do
-            let res = fromMnemonic @'[15]
+            let res = mkSomeMnemonic @'[15]
                         ["mom", "unveil", "slim", "abandon"
                         , "nut", "cash", "laugh", "impact"
                         , "system", "split", "depth", "sun"
                         ]
-            res `shouldBe` Left (FromMnemonicError "Invalid number of words: \
+            res `shouldBe` Left (MkSomeMnemonicError "Invalid number of words: \
                 \15 words are expected.")
 
         it "early error reported first (Error not in first constructor)" $ do
-            let res = fromMnemonic @'[15,18,21,24]
+            let res = mkSomeMnemonic @'[15,18,21,24]
                         ["盗", "精", "序", "郎", "赋", "姿", "委", "善", "酵"
                         ,"祥", "赛", "矩", "蜡", "注", "韦", "效", "义", "冻"
                         ]
-            res `shouldBe` Left (FromMnemonicError noInDictErr)
+            res `shouldBe` Left (MkSomeMnemonicError noInDictErr)
 
         it "early error reported first (Error not in first constructor)" $ do
-            let res = fromMnemonic @'[12,15,18]
+            let res = mkSomeMnemonic @'[12,15,18]
                         ["盗", "精", "序", "郎", "赋", "姿", "委", "善", "酵"
                         ,"祥", "赛", "矩", "蜡", "注", "韦", "效", "义", "冻"
                         ]
-            res `shouldBe` Left (FromMnemonicError noInDictErr)
+            res `shouldBe` Left (MkSomeMnemonicError noInDictErr)
 
         it "successfully parse 15 words in [15,18,21]" $ do
-            let res = fromMnemonic @'[15,18,21]
+            let res = mkSomeMnemonic @'[15,18,21]
                         ["cushion", "anxiety", "oval", "village", "choose"
                         , "shoot", "over", "behave", "category", "cruise"
                         , "track", "either", "maid", "organ", "sock"
@@ -189,7 +189,7 @@ spec = do
             res `shouldSatisfy` isRight
 
         it "successfully parse 15 words in [12,15,18]" $ do
-            let res = fromMnemonic @'[12,15,18]
+            let res = mkSomeMnemonic @'[12,15,18]
                         ["cushion", "anxiety", "oval", "village", "choose"
                         , "shoot", "over", "behave", "category", "cruise"
                         , "track", "either", "maid", "organ", "sock"
@@ -197,7 +197,7 @@ spec = do
             res `shouldSatisfy` isRight
 
         it "successfully parse 15 words in [9,12,15]" $ do
-            let res = fromMnemonic @'[9,12,15]
+            let res = mkSomeMnemonic @'[9,12,15]
                         ["cushion", "anxiety", "oval", "village", "choose"
                         , "shoot", "over", "behave", "category", "cruise"
                         , "track", "either", "maid", "organ", "sock"
@@ -349,7 +349,7 @@ spec = do
         T.splitOn ","
       . T.dropAround (\c -> c == '[' || c == ']')
 
-    isErrInvalidEntropyChecksum :: Either (MnemonicError e) b -> Bool
+    isErrInvalidEntropyChecksum :: Either (MkMnemonicError e) b -> Bool
     isErrInvalidEntropyChecksum = \case
         Left (ErrEntropy ErrInvalidEntropyChecksum{}) -> True
         _ -> False
@@ -367,7 +367,7 @@ instance
         let
             size = fromIntegral $ natVal @n Proxy
             entropy =
-                mkEntropy  @n . B8.pack <$> vector (size `quot` 8)
+                mkEntropy  @n . BA.convert . B8.pack <$> vector (size `quot` 8)
         in
             either (error . show . UnexpectedEntropyError) id <$> entropy
 


### PR DESCRIPTION
- 6a2b7f18a8ad03d3489c943680c0664db1f61fd0
  :round_pushpin: **use same cardano-crypto revision as the cardano-1.9.3 stack snapshot**
  
- 1f90c719d85f0605461ae8d69f5c9861bc3092dd
  :round_pushpin: **use stack.yaml md5 as a cache key to force cache invalidation when deps change**
  
- 919da04ef0d2b1e0782b9fcd344c481d56938720
  :round_pushpin: **add missing dot files (linter & editor config)**
  
- 7857036e7b4148e9255c869e86a1e2ad0583a144
  :round_pushpin: **documentation and naming adjustements to make the module more digestable**
