### PR TITLE
Module adjustments / simplifications

### DIFF
--- a/src/Cardano/Address/Derivation.hs
+++ b/src/Cardano/Address/Derivation.hs
@@ -1,20 +1,10 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RoleAnnotations #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Address.Derivation
     (

--- a/src/Cardano/Address/Style/Icarus.hs
+++ b/src/Cardano/Address/Style/Icarus.hs
@@ -1,18 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RoleAnnotations #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -41,11 +33,7 @@ module Cardano.Address.Style.Icarus
 import Prelude
 
 import Cardano.Address
-    ( Address (..)
-    , NetworkDiscriminant (..)
-    , PaymentAddress (..)
-    , testnetMagic
-    )
+    ( Address (..), NetworkDiscriminant (..), PaymentAddress (..) )
 import Cardano.Address.Derivation
     ( Depth (..)
     , DerivationType (..)
@@ -93,8 +81,6 @@ import Data.Word
     ( Word32 )
 import GHC.Generics
     ( Generic )
-import GHC.TypeLits
-    ( KnownNat )
 
 import qualified Cardano.Codec.Cbor as CBOR
 import qualified Crypto.ECC.Edwards25519 as Ed25519
@@ -168,17 +154,14 @@ instance SoftDerivation Icarus where
             \either a programmer error, or, we may have reached the maximum \
             \number of addresses for a given wallet."
 
-instance PaymentAddress 'Mainnet Icarus where
-    paymentAddress k = Address
+instance PaymentAddress Icarus where
+    paymentAddress discrimination k = Address
         $ CBOR.toStrictByteString
-        $ CBOR.encodeAddress (getKey k) []
-
-instance KnownNat pm => PaymentAddress ('Testnet pm) Icarus where
-    paymentAddress k = Address
-        $ CBOR.toStrictByteString
-        $ CBOR.encodeAddress (getKey k)
-            [ CBOR.encodeProtocolMagicAttr (testnetMagic @pm)
-            ]
+        $ CBOR.encodeAddress (getKey k) attrs
+      where
+        attrs = case discrimination of
+            RequiresNoMagic  -> []
+            RequiresMagic pm -> [CBOR.encodeProtocolMagicAttr pm]
 
 {-------------------------------------------------------------------------------
                                  Key generation

--- a/test/Cardano/Address/Style/IcarusSpec.hs
+++ b/test/Cardano/Address/Style/IcarusSpec.hs
@@ -19,7 +19,7 @@ module Cardano.Address.Style.IcarusSpec
 import Prelude
 
 import Cardano.Address
-    ( PaymentAddress (..), mainnetDiscriminant )
+    ( PaymentAddress (..), base58, mainnetDiscriminant )
 import Cardano.Address.Derivation
     ( AccountingStyle (..)
     , Depth (..)
@@ -35,8 +35,6 @@ import Cardano.Address.Style.Icarus
     , unsafeGenerateKeyFromHardwareLedger
     , unsafeGenerateKeyFromSeed
     )
-import Cardano.Codec.Cbor
-    ( addressToText )
 import Cardano.Crypto.Wallet
     ( XPrv )
 import Cardano.Mnemonic
@@ -230,7 +228,7 @@ data GoldenAddressGeneration = GoldenAddressGeneration
     , goldAcctIx :: Index 'Hardened 'AccountK
     , goldAcctStyle :: AccountingStyle
     , goldAddrIx :: Index 'Soft 'AddressK
-    , goldAddr :: String
+    , goldAddr :: Text
     }
 
 -- | Compare addresses obtained from a given derivation path and a root seed to
@@ -257,10 +255,8 @@ goldenAddressGeneration test = it title $ do
     title = unwords
         [ fmtPath goldAcctIx goldAcctStyle goldAddrIx
         , "-->"
-        , goldAddr
+        , T.unpack goldAddr
         ]
-
-    base58 = T.unpack . addressToText
 
     -- e.g. m/.../0'/0/0
     fmtPath p3 p4 p5 = mconcat
@@ -293,7 +289,7 @@ goldenHardwareLedger (Passphrase encPwd) sentence addrs =
 
         forM_ (zip [0..] addrs) $ \(ix, addr) -> do
             let addrXPrv = deriveAddr (toEnum ix)
-            addressToText (paymentAddress mainnetDiscriminant $ publicKey addrXPrv)
+            base58 (paymentAddress mainnetDiscriminant $ publicKey addrXPrv)
                 `shouldBe` addr
   where
     title = T.unpack

--- a/test/Cardano/Address/Style/IcarusSpec.hs
+++ b/test/Cardano/Address/Style/IcarusSpec.hs
@@ -19,7 +19,7 @@ module Cardano.Address.Style.IcarusSpec
 import Prelude
 
 import Cardano.Address
-    ( NetworkDiscriminant (..), PaymentAddress (..) )
+    ( PaymentAddress (..), mainnetDiscriminant )
 import Cardano.Address.Derivation
     ( AccountingStyle (..)
     , Depth (..)
@@ -243,7 +243,8 @@ goldenAddressGeneration test = it title $ do
     let rootXPrv = unsafeGenerateKeyFromSeed goldSeed encPwd
     let acctXPrv = deriveAccountPrivateKey encPwd rootXPrv goldAcctIx
     let addrXPrv = deriveAddressPrivateKey encPwd acctXPrv goldAcctStyle goldAddrIx
-    base58 (paymentAddress @'Mainnet $ publicKey addrXPrv) `shouldBe` goldAddr
+    base58 (paymentAddress mainnetDiscriminant $ publicKey addrXPrv)
+        `shouldBe` goldAddr
   where
     GoldenAddressGeneration
         { goldSeed
@@ -292,7 +293,8 @@ goldenHardwareLedger (Passphrase encPwd) sentence addrs =
 
         forM_ (zip [0..] addrs) $ \(ix, addr) -> do
             let addrXPrv = deriveAddr (toEnum ix)
-            addressToText (paymentAddress @'Mainnet $ publicKey addrXPrv) `shouldBe` addr
+            addressToText (paymentAddress mainnetDiscriminant $ publicKey addrXPrv)
+                `shouldBe` addr
   where
     title = T.unpack
         $ T.unwords


### PR DESCRIPTION
- 4ae694ee10e25a4860537bd432cb5ded78b87c39
  :round_pushpin: **move 'NetworkDiscriminant' down to the term level**
  There's no need to have this as a type-level constraint here. It is just adding unecessary complexity

- 8aa7abc3299f91c2bb87e6d1260c059f7b1cebcc
  :round_pushpin: **re-locate and rename/split 'addressToText' to 'base58' and 'bech32'**
  
- e77ecaa351b09f935ada68ed6f6b03bf9ad87234
  :round_pushpin: **simplify extensions' set for 'Cardano.Address.Derivation'**
