### PR TITLE
First documentation adjustments:

### DIFF
--- a/src/Cardano/Address.hs
+++ b/src/Cardano/Address.hs
@@ -152,7 +152,7 @@ stagingDiscriminant = RequiresNoMagic
 testnetDiscriminant :: NetworkDiscriminant
 testnetDiscriminant = RequiresMagic testnetMagic
 
--- | Magic constant associated to a given network. This is mainly use in two
+-- | Magic constant associated with a given network. This is mainly used in two
 -- places:
 --
 -- (1) In 'Address' payloads, to discriminate addresses between networks.

--- a/src/Cardano/Address.hs
+++ b/src/Cardano/Address.hs
@@ -14,9 +14,11 @@ module Cardano.Address
     , PaymentAddress (..)
     , unsafeMkAddress
 
-      -- * Conversion To Text
+      -- * Conversion From / To Text
     , base58
+    , fromBase58
     , bech32
+    , fromBech32
 
       -- * Network Discrimination
     , NetworkDiscriminant (..)
@@ -35,16 +37,20 @@ import Prelude
 
 import Cardano.Address.Derivation
     ( Depth (..) )
+import Cardano.Codec.Cbor
+    ( decodeAddress, deserialiseCbor )
 import Cardano.Crypto.Wallet
     ( XPub )
 import Control.DeepSeq
     ( NFData )
+import Control.Monad
+    ( (<=<) )
 import Data.ByteArray
     ( ByteArrayAccess )
 import Data.ByteString
     ( ByteString )
 import Data.ByteString.Base58
-    ( bitcoinAlphabet, encodeBase58 )
+    ( bitcoinAlphabet, decodeBase58, encodeBase58 )
 import Data.Text
     ( Text )
 import Data.Word
@@ -58,6 +64,8 @@ import qualified Data.Text.Encoding as T
 
 -- | An 'Address' type representing 'Cardano' addresses. Internals are
 -- irrevelant to the user.
+--
+-- @since 1.0.0
 newtype Address = Address
     { unAddress :: ByteString
     } deriving stock (Generic, Show, Eq, Ord)
@@ -70,26 +78,56 @@ instance NFData Address
 unsafeMkAddress :: ByteString -> Address
 unsafeMkAddress = Address
 
--- | Encode an address to base58.
+-- | Encode an 'Address' to a base58 'Text'.
+--
+-- @since 1.0.0
 base58 :: Address -> Text
 base58 = T.decodeUtf8 . encodeBase58 bitcoinAlphabet . unAddress
 
--- | Encode an address to bech32, using @addr@ as a human readable prefix.
+-- | Decode a base58-encoded 'Text' into an 'Address'
+--
+-- @since 1.0.0
+fromBase58 :: Text -> Maybe Address
+fromBase58 =
+    deserialiseCbor (unsafeMkAddress <$> decodeAddress)
+   <=<
+    decodeBase58 bitcoinAlphabet . T.encodeUtf8
+
+-- | Encode an 'Address' to bech32 'Text', using @addr@ as a human readable prefix.
+--
+-- @since 1.0.0
 bech32 :: Address -> Text
 bech32 = Bech32.encodeLenient hrp . Bech32.dataPartFromBytes . unAddress
   where
     hrp = [Bech32.humanReadablePart|addr|]
 
+-- | Decode a bech32-encoded  'Text' into an 'Address'
+--
+-- @since 1.0.0
+fromBech32 :: Text -> Maybe Address
+fromBech32 =
+    fmap unsafeMkAddress . Bech32.dataPartToBytes
+   <=<
+    either (const Nothing) (Just . snd) . Bech32.decodeLenient
+
 -- | Encoding of addresses for certain key types and backend targets.
+--
+-- @since 1.0.0
 class PaymentAddress key where
     -- | Convert a public key to a payment 'Address' valid for the given
     -- network discrimination.
     --
-    -- Note that 'paymentAddress' is ambiguous and requires therefore a type
-    -- application.
+    -- @since 1.0.0
     paymentAddress :: NetworkDiscriminant -> key 'AddressK XPub -> Address
 
--- | Available network options.
+-- | Describe required network discrimination. See also the available
+-- smart-constructors if you are not sure about what to do with this:
+--
+-- - 'mainnetDiscriminant'
+-- - 'stagingDiscriminant'
+-- - 'testnetDiscriminant'
+--
+-- @since 1.0.0
 data NetworkDiscriminant
     = RequiresNoMagic
     | RequiresMagic ProtocolMagic
@@ -97,35 +135,49 @@ data NetworkDiscriminant
 instance NFData NetworkDiscriminant
 
 -- | Required network discrimination settings for mainnet
+--
+-- @since 1.0.0
 mainnetDiscriminant :: NetworkDiscriminant
 mainnetDiscriminant = RequiresNoMagic
 
 -- | Required network discrimination settings for staging
+--
+-- @since 1.0.0
 stagingDiscriminant :: NetworkDiscriminant
 stagingDiscriminant = RequiresNoMagic
 
 -- | Required network discrimination settings for testnet
+--
+-- @since 1.0.0
 testnetDiscriminant :: NetworkDiscriminant
 testnetDiscriminant = RequiresMagic testnetMagic
 
 -- | Magic constant associated to a given network. This is mainly use in two
 -- places:
 --
--- a) In 'Address' payloads, to discriminate addresses between networks.
--- b) At the network-level, when doing handshake with nodes.
+-- (1) In 'Address' payloads, to discriminate addresses between networks.
+-- (2) At the network-level, when doing handshake with nodes.
+--
+-- @since 1.0.0
 newtype ProtocolMagic
     = ProtocolMagic { getProtocolMagic :: Word32 }
     deriving (Generic, Show, Eq)
 instance NFData ProtocolMagic
 
 -- | Hard-coded 'ProtocolMagic' for Cardano MainNet
+--
+-- @since 1.0.0
 mainnetMagic :: ProtocolMagic
 mainnetMagic =  ProtocolMagic 764824073
 
 -- | Hard-coded 'ProtocolMagic' for Cardano Staging
+--
+-- @since 1.0.0
 stagingMagic :: ProtocolMagic
 stagingMagic = ProtocolMagic 633343913
 
 -- | Hard-coded 'ProtocolMagic' for Cardano standard TestNet
+--
+-- @since 1.0.0
 testnetMagic :: ProtocolMagic
 testnetMagic = ProtocolMagic 1097911063

--- a/src/Cardano/Address.hs
+++ b/src/Cardano/Address.hs
@@ -1,13 +1,18 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 
+{-# OPTIONS_HADDOCK prune #-}
+
 module Cardano.Address
     ( -- * Address
-      Address (..)
+      Address
     , PaymentAddress (..)
+    , unsafeMkAddress
 
       -- * Conversion To Text
     , base58
@@ -34,6 +39,8 @@ import Cardano.Crypto.Wallet
     ( XPub )
 import Control.DeepSeq
     ( NFData )
+import Data.ByteArray
+    ( ByteArrayAccess )
 import Data.ByteString
     ( ByteString )
 import Data.ByteString.Base58
@@ -49,11 +56,19 @@ import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.Text.Encoding as T
 
--- | Address is mere wrapper around a ByteString and represents an encoded address.
+-- | An 'Address' type representing 'Cardano' addresses. Internals are
+-- irrevelant to the user.
 newtype Address = Address
     { unAddress :: ByteString
-    } deriving (Generic, Show, Eq, Ord)
+    } deriving stock (Generic, Show, Eq, Ord)
+      deriving newtype (ByteArrayAccess)
 instance NFData Address
+
+-- Unsafe constructor for easily lifting bytes inside an 'Address'.
+--
+-- /!\ Use at your own risks.
+unsafeMkAddress :: ByteString -> Address
+unsafeMkAddress = Address
 
 -- | Encode an address to base58.
 base58 :: Address -> Text

--- a/src/Cardano/Address/Style/Byron.hs
+++ b/src/Cardano/Address/Style/Byron.hs
@@ -36,7 +36,7 @@ module Cardano.Address.Style.Byron
 import Prelude
 
 import Cardano.Address
-    ( Address (..), NetworkDiscriminant (..), PaymentAddress (..) )
+    ( NetworkDiscriminant (..), PaymentAddress (..), unsafeMkAddress )
 import Cardano.Address.Derivation
     ( Depth (..)
     , DerivationType (..)
@@ -127,7 +127,7 @@ instance HardDerivation Byron where
         }
 
 instance PaymentAddress Byron where
-    paymentAddress discrimination k = Address
+    paymentAddress discrimination k = unsafeMkAddress
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k) attrs
       where

--- a/src/Cardano/Address/Style/Icarus.hs
+++ b/src/Cardano/Address/Style/Icarus.hs
@@ -33,7 +33,11 @@ module Cardano.Address.Style.Icarus
 import Prelude
 
 import Cardano.Address
-    ( NetworkDiscriminant (..), PaymentAddress (..), unsafeMkAddress )
+    ( NetworkDiscriminant (..)
+    , PaymentAddress (..)
+    , ProtocolMagic (..)
+    , unsafeMkAddress
+    )
 import Cardano.Address.Derivation
     ( Depth (..)
     , DerivationType (..)
@@ -161,7 +165,9 @@ instance PaymentAddress Icarus where
       where
         attrs = case discrimination of
             RequiresNoMagic  -> []
-            RequiresMagic pm -> [CBOR.encodeProtocolMagicAttr pm]
+            RequiresMagic (ProtocolMagic pm) ->
+                [ CBOR.encodeProtocolMagicAttr pm
+                ]
 
 {-------------------------------------------------------------------------------
                                  Key generation

--- a/src/Cardano/Address/Style/Icarus.hs
+++ b/src/Cardano/Address/Style/Icarus.hs
@@ -33,7 +33,7 @@ module Cardano.Address.Style.Icarus
 import Prelude
 
 import Cardano.Address
-    ( Address (..), NetworkDiscriminant (..), PaymentAddress (..) )
+    ( NetworkDiscriminant (..), PaymentAddress (..), unsafeMkAddress )
 import Cardano.Address.Derivation
     ( Depth (..)
     , DerivationType (..)
@@ -155,7 +155,7 @@ instance SoftDerivation Icarus where
             \number of addresses for a given wallet."
 
 instance PaymentAddress Icarus where
-    paymentAddress discrimination k = Address
+    paymentAddress discrimination k = unsafeMkAddress
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k) attrs
       where

--- a/src/Cardano/Codec/Cbor.hs
+++ b/src/Cardano/Codec/Cbor.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
+{-# OPTIONS_HADDOCK hide #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -42,7 +44,7 @@ module Cardano.Codec.Cbor
 import Prelude
 
 import Cardano.Address
-    ( Address (..), ProtocolMagic (..) )
+    ( Address, ProtocolMagic (..), unsafeMkAddress )
 import Cardano.Address.Derivation
     ( Depth (..), DerivationType (..), Index (..) )
 import Cardano.Crypto.Wallet
@@ -266,7 +268,7 @@ decodeAddress = do
     --
     -- NOTE 2:
     -- We may want to check the CRC at this level as-well... maybe not.
-    return $ Address $ CBOR.toStrictByteString $ mempty
+    return $ unsafeMkAddress $ CBOR.toStrictByteString $ mempty
         <> CBOR.encodeListLen 2
         <> CBOR.encodeTag tag
         <> CBOR.encodeBytes bytes

--- a/src/Cardano/Codec/Cbor.hs
+++ b/src/Cardano/Codec/Cbor.hs
@@ -43,10 +43,6 @@ module Cardano.Codec.Cbor
 
 import Prelude
 
-import Cardano.Address
-    ( Address, ProtocolMagic (..), unsafeMkAddress )
-import Cardano.Address.Derivation
-    ( Depth (..), DerivationType (..), Index (..) )
 import Cardano.Crypto.Wallet
     ( ChainCode (..), XPub (..) )
 import Control.Monad
@@ -70,7 +66,7 @@ import Data.Either.Extra
 import Data.List
     ( find )
 import Data.Word
-    ( Word8 )
+    ( Word32, Word8 )
 import GHC.Stack
     ( HasCallStack )
 
@@ -190,21 +186,18 @@ encodeAttributes attrs = CBOR.encodeMapLen l <> mconcat attrs
   where
     l = fromIntegral (length attrs)
 
-encodeProtocolMagicAttr :: ProtocolMagic -> CBOR.Encoding
+encodeProtocolMagicAttr :: Word32 -> CBOR.Encoding
 encodeProtocolMagicAttr pm = mempty
     <> CBOR.encodeWord 2 -- Tag for 'ProtocolMagic' attribute
-    <> CBOR.encodeBytes (CBOR.toStrictByteString $ encodeProtocolMagic pm)
-
-encodeProtocolMagic :: ProtocolMagic -> CBOR.Encoding
-encodeProtocolMagic (ProtocolMagic i) = CBOR.encodeWord32 i
+    <> CBOR.encodeBytes (CBOR.toStrictByteString $ CBOR.encodeWord32 pm)
 
 -- This is the opposite of 'decodeDerivationPathAttr'.
 --
 -- NOTE: The caller must ensure that the passphrase length is 32 bytes.
 encodeDerivationPathAttr
     :: ScrubbedBytes
-    -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    -> Word32
+    -> Word32
     -> CBOR.Encoding
 encodeDerivationPathAttr pwd acctIx addrIx = mempty
     <> CBOR.encodeWord8 1 -- Tag for 'DerivationPath' attribute
@@ -213,10 +206,10 @@ encodeDerivationPathAttr pwd acctIx addrIx = mempty
     path = encodeDerivationPath acctIx addrIx
 
 encodeDerivationPath
-    :: Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    :: Word32
+    -> Word32
     -> CBOR.Encoding
-encodeDerivationPath (Index acctIx) (Index addrIx) = mempty
+encodeDerivationPath acctIx addrIx = mempty
     <> CBOR.encodeListLenIndef
     <> CBOR.encodeWord32 acctIx
     <> CBOR.encodeWord32 addrIx
@@ -252,7 +245,7 @@ encryptDerivationPath pwd payload = unsafeSerialize $ do
 cardanoNonce :: ByteString
 cardanoNonce = "serokellfore"
 
-decodeAddress :: CBOR.Decoder s Address
+decodeAddress :: CBOR.Decoder s ByteString
 decodeAddress = do
     _ <- CBOR.decodeListLenCanonicalOf 2
         -- CRC Protection Wrapper
@@ -268,7 +261,7 @@ decodeAddress = do
     --
     -- NOTE 2:
     -- We may want to check the CRC at this level as-well... maybe not.
-    return $ unsafeMkAddress $ CBOR.toStrictByteString $ mempty
+    return $ CBOR.toStrictByteString $ mempty
         <> CBOR.encodeListLen 2
         <> CBOR.encodeTag tag
         <> CBOR.encodeBytes bytes
@@ -284,10 +277,7 @@ decodeAddressPayload = do
 
 decodeAddressDerivationPath
     :: ScrubbedBytes
-    -> CBOR.Decoder s (Maybe
-        ( Index 'WholeDomain 'AccountK
-        , Index 'WholeDomain 'AddressK
-        ))
+    -> CBOR.Decoder s (Maybe (Word32, Word32))
 decodeAddressDerivationPath pwd = do
     _ <- CBOR.decodeListLenCanonicalOf 3
     _ <- CBOR.decodeBytes
@@ -301,19 +291,16 @@ decodeAddressDerivationPath pwd = do
     pure path
 
 decodeProtocolMagicAttr
-    :: CBOR.Decoder s (Maybe ProtocolMagic)
+    :: CBOR.Decoder s (Maybe Word32)
 decodeProtocolMagicAttr = do
     _ <- CBOR.decodeListLenCanonicalOf 3
     _ <- CBOR.decodeBytes
     attrs <- decodeAllAttributes
     case find ((== 2) . fst) attrs of
         Nothing -> pure Nothing
-        Just (_, bytes) -> case deserialiseCbor decodeProtocolMagic bytes of
+        Just (_, bytes) -> case deserialiseCbor CBOR.decodeWord32 bytes of
             Nothing -> fail "unable to decode attribute into protocol magic"
             Just pm -> pure (Just pm)
-  where
-    decodeProtocolMagic :: CBOR.Decoder s ProtocolMagic
-    decodeProtocolMagic = ProtocolMagic <$> CBOR.decodeWord32
 
 -- | The attributes are pairs of numeric tags and bytes, where the bytes will be
 -- CBOR-encoded stuff. This decoder does not enforce "canonicity" of entries.
@@ -328,10 +315,7 @@ decodeAllAttributes = do
 decodeDerivationPathAttr
     :: ScrubbedBytes
     -> [(Word8, ByteString)]
-    -> CBOR.Decoder s (Maybe
-        ( Index 'WholeDomain 'AccountK
-        , Index 'WholeDomain 'AddressK
-        ))
+    -> CBOR.Decoder s (Maybe (Word32, Word32))
 decodeDerivationPathAttr pwd attrs = do
     case lookup derPathTag attrs of
         Just payload -> do
@@ -342,10 +326,7 @@ decodeDerivationPathAttr pwd attrs = do
             ]
   where
     derPathTag = 1
-    decoder :: CBOR.Decoder s (Maybe
-        ( Index 'WholeDomain 'AccountK
-        , Index 'WholeDomain 'AddressK
-        ))
+    decoder :: CBOR.Decoder s (Maybe (Word32, Word32))
     decoder = do
         bytes <- CBOR.decodeBytes
         case decryptDerivationPath pwd bytes of
@@ -373,15 +354,12 @@ decryptDerivationPath pwd bytes = do
 
 -- Opposite of 'encodeDerivationPath'.
 decodeDerivationPath
-    :: CBOR.Decoder s
-        ( Index 'WholeDomain 'AccountK
-        , Index 'WholeDomain 'AddressK
-        )
+    :: CBOR.Decoder s (Word32, Word32)
 decodeDerivationPath = do
     ixs <- decodeListIndef CBOR.decodeWord32
     case ixs of
         [acctIx, addrIx] ->
-            pure (toEnum $ fromIntegral acctIx, toEnum $ fromIntegral addrIx)
+            pure (acctIx, addrIx)
         _ ->
             fail $ mconcat
                 [ "decodeDerivationPath: invalid derivation path payload: "

--- a/src/Cardano/Mnemonic.hs
+++ b/src/Cardano/Mnemonic.hs
@@ -22,12 +22,10 @@ module Cardano.Mnemonic
       -- * Introduction
       -- $introduction
 
-      -- * @Entropy@
-      Entropy
-    , genEntropy
-    , mkEntropy
-    , entropyToBytes
-    , entropyToMnemonic
+      -- * @SomeMnemonic@
+      SomeMnemonic(..)
+    , mkSomeMnemonic
+    , MkSomeMnemonicError(..)
 
       -- * @Mnemonic@
     , Mnemonic
@@ -36,10 +34,12 @@ module Cardano.Mnemonic
     , mnemonicToText
     , mnemonicToEntropy
 
-      -- * @SomeMnemonic@
-    , SomeMnemonic(..)
-    , mkSomeMnemonic
-    , MkSomeMnemonicError(..)
+      -- * @Entropy@
+    , Entropy
+    , genEntropy
+    , mkEntropy
+    , entropyToBytes
+    , entropyToMnemonic
 
       -- Internals & Re-export from @Crypto.Encoding.BIP39@
     , EntropyError(..)

--- a/test/Cardano/Codec/CborSpec.hs
+++ b/test/Cardano/Codec/CborSpec.hs
@@ -17,7 +17,7 @@ module Cardano.Codec.CborSpec
 import Prelude
 
 import Cardano.Address.Derivation
-    ( Depth (..), DerivationType (..), Index (..) )
+    ( Depth (..) )
 import Cardano.Address.Style.Byron
     ( Byron (..), unsafeGenerateKeyFromSeed )
 import Cardano.Codec.Cbor
@@ -138,7 +138,7 @@ arbitraryMnemonic =
 
 decodeDerivationPathTest :: DecodeDerivationPath -> Expectation
 decodeDerivationPathTest DecodeDerivationPath{..} =
-    decoded `shouldBe` Just (Just (Index accIndex, Index addrIndex))
+    decoded `shouldBe` Just (Just (accIndex, addrIndex))
   where
     payload = unsafeDeserialiseCbor decodeAddressPayload $
         BL.fromStrict (unsafeFromHex addr)
@@ -154,8 +154,8 @@ decodeDerivationPathTest DecodeDerivationPath{..} =
 prop_derivationPathRoundTrip
     :: Passphrase
     -> Passphrase
-    -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    -> Word32
+    -> Word32
     -> Property
 prop_derivationPathRoundTrip (Passphrase pwd) (Passphrase pwd') acctIx addrIx =
     let

--- a/test/Cardano/MnemonicSpec.hs
+++ b/test/Cardano/MnemonicSpec.hs
@@ -1,15 +1,9 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
-
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.MnemonicSpec
     ( spec


### PR DESCRIPTION
# Overview

- 21fb4567c2a591c34624c97471bddc43589f2658
  :round_pushpin: **revise module export hierarchy in Cardano.Mnemonic**
  Put the most useful stuff on the top, and the more internal ones on the bottom.

- e6a373c9f93211f2122a9e1f21de88469c50642a
  :round_pushpin: **hide the internal constructor for 'Address'**
  This only adds noise and may encourage people to construct their own address from
scratch. So, we only publicly expose an opaque 'Address' type and keep the internals
hidden. Still, a careful and curious reader looking at the source may decide to do
otherwise, which is fine.

- 9189c7e6a2477ad4cd0e32a90307b3ee6638cdc8
  :round_pushpin: **have function for doing address encoding / decoding inside 'Cardano.Address'**
  I had to remove some circular dependencies with Cardano.Codec.Cbor in order to do that and therefore, resorted to use more primitives in this low-level module

- afce3ad8384b7b645b52df5fcce833bae946b7fc
  :round_pushpin: **cleanup unnecessary extensions from Cardano.MnemonicSpec**
  


# Comments

TODO: add roundtrip tests for encoding/decoding bech32 and base58 addresses (I am on it).