### PR TITLE
add roundtrip tests for address encoding/decoding

### DIFF
--- a/src/Cardano/Address/Style/Byron.hs
+++ b/src/Cardano/Address/Style/Byron.hs
@@ -31,6 +31,8 @@ module Cardano.Address.Style.Byron
     , mkByronKeyFromMasterKey
     , unsafeMkByronKeyFromMasterKey
 
+      -- * Temporary
+    , publicKey
     ) where
 
 import Prelude
@@ -239,6 +241,14 @@ unsafeMkByronKeyFromMasterKey derivationPath masterKey = Byron
 --
 -- Internal
 --
+
+-- Temporary, we should really make 'Byron' a 'Functor'
+publicKey :: Byron depth XPrv -> Byron depth XPub
+publicKey Byron{getKey,derivationPath,payloadPassphrase} = Byron
+    { getKey = toXPub getKey
+    , derivationPath
+    , payloadPassphrase
+    }
 
 word32 :: Enum a => a -> Word32
 word32 = fromIntegral . fromEnum

--- a/test/Cardano/AddressSpec.hs
+++ b/test/Cardano/AddressSpec.hs
@@ -29,15 +29,14 @@ import Data.Function
     ( (&) )
 import Data.Text
     ( Text )
+import Test.Arbitrary
+    ()
 import Test.Hspec
     ( Spec, describe )
 import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
     ( Property, counterexample, label )
-
-import Test.Arbitrary
-    ()
 
 import qualified Data.Text as T
 
@@ -55,8 +54,8 @@ spec = describe "Text Encoding Roundtrips" $ do
     prop "bech32 . fromBech32 - Icarus" $
         prop_roundtripTextEncoding @Icarus bech32 fromBech32
 
--- Ensure that any address public key can be encoded to an address and that
--- address can be encoded and decoded without issue.
+-- Ensure that any address public key can be encoded to an address and that the
+-- address can be encoded and decoded without issues.
 prop_roundtripTextEncoding
     :: PaymentAddress k
     => (Address -> Text)
@@ -68,7 +67,7 @@ prop_roundtripTextEncoding
     -> NetworkDiscriminant
         -- ^ An arbitrary network discriminant
     -> Property
-prop_roundtripTextEncoding encode decode pub discrimination =
+prop_roundtripTextEncoding encode decode addXPub discrimination =
     (result == pure address)
         & counterexample (unlines
             [ "Address " <> T.unpack (encode address)
@@ -76,7 +75,7 @@ prop_roundtripTextEncoding encode decode pub discrimination =
             ])
         & label (constructor discrimination)
   where
-    address = paymentAddress discrimination pub
+    address = paymentAddress discrimination addXPub
     result  = decode (encode address)
     constructor = \case
         RequiresMagic{} -> "RequiresMagic"

--- a/test/Cardano/AddressSpec.hs
+++ b/test/Cardano/AddressSpec.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.AddressSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Address
+    ( Address
+    , NetworkDiscriminant (..)
+    , PaymentAddress (..)
+    , base58
+    , bech32
+    , fromBase58
+    , fromBech32
+    )
+import Cardano.Address.Derivation
+    ( Depth (..) )
+import Cardano.Address.Style.Byron
+    ( Byron )
+import Cardano.Address.Style.Icarus
+    ( Icarus )
+import Cardano.Crypto.Wallet
+    ( XPub )
+import Data.Function
+    ( (&) )
+import Data.Text
+    ( Text )
+import Test.Hspec
+    ( Spec, describe )
+import Test.Hspec.QuickCheck
+    ( prop )
+import Test.QuickCheck
+    ( Property, counterexample, label )
+
+import Test.Arbitrary
+    ()
+
+import qualified Data.Text as T
+
+spec :: Spec
+spec = describe "Text Encoding Roundtrips" $ do
+    prop "base58 . fromBase58 - Byron" $
+        prop_roundtripTextEncoding @Byron base58 fromBase58
+
+    prop "base58 . fromBase58 - Icarus" $
+        prop_roundtripTextEncoding @Icarus base58 fromBase58
+
+    prop "bech32 . fromBech32 - Byron" $
+        prop_roundtripTextEncoding @Byron bech32 fromBech32
+
+    prop "bech32 . fromBech32 - Icarus" $
+        prop_roundtripTextEncoding @Icarus bech32 fromBech32
+
+-- Ensure that any address public key can be encoded to an address and that
+-- address can be encoded and decoded without issue.
+prop_roundtripTextEncoding
+    :: PaymentAddress k
+    => (Address -> Text)
+        -- ^ encode to 'Text'
+    -> (Text -> Maybe Address)
+        -- ^ decode from 'Text'
+    -> k 'AddressK XPub
+        -- ^ An arbitrary public key
+    -> NetworkDiscriminant
+        -- ^ An arbitrary network discriminant
+    -> Property
+prop_roundtripTextEncoding encode decode pub discrimination =
+    (result == pure address)
+        & counterexample (unlines
+            [ "Address " <> T.unpack (encode address)
+            , "↳       " <> maybe "ø" (T.unpack . encode) result
+            ])
+        & label (constructor discrimination)
+  where
+    address = paymentAddress discrimination pub
+    result  = decode (encode address)
+    constructor = \case
+        RequiresMagic{} -> "RequiresMagic"
+        RequiresNoMagic -> "RequiresNoMagic"


### PR DESCRIPTION
- d83d74894ced10f04674a4e5d2599158986f3fb6
  :round_pushpin: **add roundtrip tests for address encoding/decoding**
    When failing, the intermediate address is shown, as well as the
  decoded output.

  ```
  Falsified (after 1 test):

  Byron {getKey = XPub {xpubPublicKey = "\DC2\149\ENQ\SUB\238s\237\158\156\DC1\ar\EMAli\200\&9.=&\232\GS84\157\216;\173\192\227\STX", xpubChaincode = ChainCode "o\ENQl\185?e\133z\RSb\149\135y>\147\133\237Z\252\187\157W\ENQ8\200:\t\141\196oo\170"}, derivationPath = (Index {getIndex = 2296535368},Index {getIndex = 2550258752}), payloadPassphrase = <scrubbed-bytes>}
  RequiresMagic (ProtocolMagic {getProtocolMagic = 1})
  Address KjgoiXJS2coNC8fv21Q2gVfjMdSjyWifXkLV64yHrqCrxH83hnoXCw3K5SsATzfZn5aQ1ZQ5tNYrp4YfB8eSUbD53sb7WivYoFej49X5Kyeb
  ↳       2RhQhCGjwU91eY8rm1SkeRKXwx3rcgSAu4iGzyNXTQwmMUzA6w3ALKfXCndAQn9XDfyCQZTztZk7criejVikFSmzGsgHZkC3MM9fWctbk6m2uu
  ```

  On success, we get some coverage indication:

  ```
  base58 . fromBase58 - Byron
    +++ OK, passed 100 tests:
    65% RequiresNoMagic
    35% RequiresMagic
  base58 . fromBase58 - Icarus
    +++ OK, passed 100 tests:
    65% RequiresNoMagic
    35% RequiresMagic
  bech32 . fromBech32 - Byron
    +++ OK, passed 100 tests:
    65% RequiresNoMagic
    35% RequiresMagic
  bech32 . fromBech32 - Icarus
    +++ OK, passed 100 tests:
    65% RequiresNoMagic
    35% RequiresMagic
  ```

