### PR TITLE
cardano-crypto wrapper

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -44,6 +44,7 @@
   - {name: [Data.Set, Data.HashSet], as: Set}
   - {name: [Data.Text, Data.Text.Encoding], as: T}
   - {name: [Data.Vector], as: V}
+  - {name: Cardano.Crypto.Wallet, within: [Cardano.Address.Derivation,Cardano.Codec.Cbor]} # Import wrapped types & methods from 'Cardano.Address.Derivation' instead
 
 # Ignore some build-in rules
 - ignore: {name: "Reduce duplication"} # This is a decision left to developers and reviewers

--- a/src/Cardano/Address.hs
+++ b/src/Cardano/Address.hs
@@ -36,11 +36,9 @@ module Cardano.Address
 import Prelude
 
 import Cardano.Address.Derivation
-    ( Depth (..) )
+    ( Depth (..), XPub )
 import Cardano.Codec.Cbor
     ( decodeAddress, deserialiseCbor )
-import Cardano.Crypto.Wallet
-    ( XPub )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad

--- a/src/Cardano/Address/Derivation.hs
+++ b/src/Cardano/Address/Derivation.hs
@@ -53,6 +53,7 @@ module Cardano.Address.Derivation
 
 import Prelude
 
+import Data.Either.Extra (eitherToMaybe)
 import GHC.Stack
     (HasCallStack )
 import Cardano.Crypto.Wallet
@@ -177,7 +178,7 @@ verify
     -> XSignature
     -> Bool
 verify =
-    CC.verify -- re-exported like to allow documenting it.
+    CC.verify -- re-exported for the sake of documentation.
 
 -- Derive a child extended private key from an extended private key
 --
@@ -392,13 +393,3 @@ class GenMasterKey (key :: Depth -> * -> *) where
     --
     -- @since 1.0.0
     genMasterKey :: GenMasterKeyFrom key -> key 'RootK XPrv
-
-
---
--- Internals
---
-
--- Simple helper to convert 'Either e' to 'Maybe' until we have a slightly
--- better approach for error.
-eitherToMaybe :: Either e a -> Maybe a
-eitherToMaybe = either (const Nothing) Just

--- a/src/Cardano/Address/Derivation.hs
+++ b/src/Cardano/Address/Derivation.hs
@@ -6,31 +6,63 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
+{-# OPTIONS_HADDOCK prune #-}
+
 module Cardano.Address.Derivation
     (
     -- * Overview
     -- $overview
 
-    -- * Abstractions
-      GenMasterKey (..)
-    , HardDerivation (..)
-    , SoftDerivation (..)
-
-    -- * Helper types
-    , Index (..)
+    -- * Key Derivation
+    -- ** Types
+      Index
     , Depth (..)
     , DerivationType (..)
     , AccountingStyle (..)
+
+    -- * Abstractions
+    , GenMasterKey (..)
+    , HardDerivation (..)
+    , SoftDerivation (..)
+
+    -- * Low-Level Cryptography
+    -- ** XPub
+    , XPub
+    , xpubFromBytes
+    , xpubToBytes
+
+    -- ** XPrv
+    , XPrv
+    , xprvFromBytes
+    , xprvToBytes
+    , toXPub
+
+    -- ** XSignature
+    , XSignature
+    , sign
+    , verify
+
+    -- Internal / Not exposed by Haddock
+    , DerivationScheme (..)
+    , deriveXPrv
+    , deriveXPub
+    , generate
+    , generateNew
+    ------------------
     ) where
 
 import Prelude
 
+import GHC.Stack
+    (HasCallStack )
 import Cardano.Crypto.Wallet
-    ( XPrv, XPub )
+    ( DerivationScheme (..) )
 import Control.DeepSeq
     ( NFData )
 import Data.ByteArray
-    ( ScrubbedBytes )
+    ( ByteArrayAccess, ScrubbedBytes )
+import Data.ByteString
+    ( ByteString )
 import Data.String
     ( fromString )
 import Data.Typeable
@@ -41,12 +73,158 @@ import Fmt
     ( Buildable (..) )
 import GHC.Generics
     ( Generic )
+import Crypto.Error
+    ( eitherCryptoError )
+
+import qualified Cardano.Crypto.Wallet as CC
+import qualified Data.ByteString as BS
+import qualified Crypto.ECC.Edwards25519 as Ed25519
 
 -- $overview
 --
 -- These abstractions allow generating root private key, also called /Master Key/
 -- and then basing on it enable address derivation
 
+--
+-- Low-Level Cryptography
+--
+
+-- | An opaque type representing an extended private key.
+--
+-- @since 1.0.0
+type XPrv = CC.XPrv
+
+-- | An opaque type representing an extended public key.
+--
+-- @since 1.0.0
+type XPub = CC.XPub
+
+-- | An opaque type representing a signature made from an 'XPrv'
+--
+-- @since 1.0.0
+type XSignature = CC.XSignature
+
+-- | Construct an 'XPub' from raw 'ByteString'
+--
+-- @since 1.0.0
+xpubFromBytes :: ByteString -> Maybe XPub
+xpubFromBytes =
+    eitherToMaybe . CC.xpub
+
+-- | Convert an 'XPub' to a raw 'ByteString'
+--
+-- @since 1.0.0
+xpubToBytes :: XPub -> ByteString
+xpubToBytes =
+    CC.unXPub
+
+-- | Construct an 'XPrv' from raw 'ByteString'.
+--
+-- @since 1.0.0
+xprvFromBytes :: ByteString -> Maybe XPrv
+xprvFromBytes bytes
+    | BS.length bytes /= 96 = Nothing
+    | otherwise = do
+        let (prv, cc) = BS.splitAt 64 bytes
+        pub <- ed25519ScalarMult (BS.take 32 prv)
+        eitherToMaybe $ CC.xprv $ prv <> pub <> cc
+  where
+    ed25519ScalarMult :: ByteString -> Maybe ByteString
+    ed25519ScalarMult bs = do
+        scalar <- eitherToMaybe $ eitherCryptoError $ Ed25519.scalarDecodeLong bs
+        pure $ Ed25519.pointEncode $ Ed25519.toPoint scalar
+
+-- | Convert an 'XPrv' to a raw 'ByteString'.
+--
+-- @since 1.0.0
+xprvToBytes :: XPrv -> ByteString
+xprvToBytes =
+    stripPub . CC.unXPrv
+  where
+    -- From  < xprv | pub | cc >
+    -- ↳ To  < xprv |     | cc >
+    stripPub :: ByteString -> ByteString
+    stripPub xprv' = prv <> chainCode
+      where
+        (prv, rest) = BS.splitAt 64 xprv'
+        (_pub, chainCode) = BS.splitAt 32 rest
+
+-- | Derive the 'XPub' from a corresponding 'XPrv'.
+--
+-- @since 1.0.0
+toXPub :: HasCallStack => XPrv -> XPub
+toXPub = CC.toXPub
+
+-- | Produce a signature of the given 'msg' from an 'XPrv'.
+--
+-- @since 1.0.0
+sign
+    :: ByteArrayAccess msg
+    => XPrv
+    -> msg
+    -> XSignature
+sign =
+    CC.sign (mempty :: ScrubbedBytes)
+
+-- | Verify the 'XSignature' of a 'msg' with the 'XPub' associated with the
+-- 'XPrv' used for signing.
+--
+-- @since 1.0.0
+verify
+    :: ByteArrayAccess msg
+    => XPub
+    -> msg
+    -> XSignature
+    -> Bool
+verify =
+    CC.verify -- re-exported like to allow documenting it.
+
+-- Derive a child extended private key from an extended private key
+--
+-- __internal__
+deriveXPrv
+    :: DerivationScheme
+    -> XPrv
+    -> Index derivationType depth
+    -> XPrv
+deriveXPrv ds prv (Index ix) =
+    CC.deriveXPrv ds (mempty :: ScrubbedBytes) prv ix
+
+-- Derive a child extended public key from an extended public key
+--
+-- __internal__
+deriveXPub
+    :: DerivationScheme
+    -> XPub
+    -> Index derivationType depth
+    -> Maybe XPub
+deriveXPub ds pub (Index ix) =
+    CC.deriveXPub ds pub ix
+
+-- Generate an XPrv using the legacy method (Byron).
+--
+-- The seed needs to be at least 32 bytes, otherwise an asynchronous error is thrown.
+generate
+    :: ByteArrayAccess seed
+    => seed
+    -> XPrv
+generate seed =
+    CC.generate seed (mempty :: ScrubbedBytes)
+
+-- Generate an XPrv using the new method (Icarus).
+--
+-- The seed needs to be at least 16 bytes.
+generateNew
+    :: (ByteArrayAccess seed, ByteArrayAccess sndFactor)
+    => seed
+    -> sndFactor
+    -> XPrv
+generateNew seed sndFactor =
+    CC.generateNew seed sndFactor (mempty :: ScrubbedBytes)
+
+--
+-- Key Derivation
+--
 
 -- | Key Depth in the derivation path, according to BIP-0039 / BIP-0044
 --
@@ -156,8 +334,7 @@ class HardDerivation (key :: Depth -> * -> *) where
     -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
     -- package for more details).
     deriveAccountPrivateKey
-        :: ScrubbedBytes
-        -> key 'RootK XPrv
+        :: key 'RootK XPrv
         -> Index (AccountIndexDerivationType key) 'AccountK
         -> key 'AccountK XPrv
 
@@ -165,8 +342,7 @@ class HardDerivation (key :: Depth -> * -> *) where
     -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
     -- package for more details).
     deriveAddressPrivateKey
-        :: ScrubbedBytes
-        -> key 'AccountK XPrv
+        :: key 'AccountK XPrv
         -> AccountingStyle
         -> Index (AddressIndexDerivationType key) 'AddressK
         -> key 'AddressK XPrv
@@ -190,4 +366,14 @@ class GenMasterKey (key :: Depth -> * -> *) where
     type GenMasterKeyFrom key :: *
 
     -- | Generate a root key from a corresponding seed.
-    genMasterKey :: GenMasterKeyFrom key -> ScrubbedBytes -> key 'RootK XPrv
+    genMasterKey :: GenMasterKeyFrom key -> key 'RootK XPrv
+
+
+--
+-- Internals
+--
+
+-- Simple helper to convert 'Either e' to 'Maybe' until we have a slightly
+-- better approach for error.
+eitherToMaybe :: Either e a -> Maybe a
+eitherToMaybe = either (const Nothing) Just

--- a/src/Cardano/Address/Style/Byron.hs
+++ b/src/Cardano/Address/Style/Byron.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -23,16 +24,16 @@
 
 module Cardano.Address.Style.Byron
     ( -- * Types
-      Byron(..)
+      Byron
+    , payloadPassphrase
+    , derivationPath
+    , getKey
 
       -- * Generation
     , unsafeGenerateKeyFromSeed
     , minSeedLengthBytes
     , mkByronKeyFromMasterKey
     , unsafeMkByronKeyFromMasterKey
-
-      -- * Temporary
-    , publicKey
     ) where
 
 import Prelude
@@ -100,6 +101,7 @@ data Byron (depth :: Depth) key = Byron
 instance (NFData key, NFData (DerivationPath depth)) => NFData (Byron depth key)
 deriving instance (Show key, Show (DerivationPath depth)) => Show (Byron depth key)
 deriving instance (Eq key, Eq (DerivationPath depth)) => Eq (Byron depth key)
+deriving instance (Functor (Byron depth))
 
 -- | The hierarchical derivation indices for a given level/depth.
 type family DerivationPath (depth :: Depth) :: * where
@@ -238,14 +240,6 @@ unsafeMkByronKeyFromMasterKey derivationPath masterKey = Byron
 --
 -- Internal
 --
-
--- Temporary, we should really make 'Byron' a 'Functor'
-publicKey :: Byron depth XPrv -> Byron depth XPub
-publicKey Byron{getKey,derivationPath,payloadPassphrase} = Byron
-    { getKey = toXPub getKey
-    , derivationPath
-    , payloadPassphrase
-    }
 
 word32 :: Enum a => a -> Word32
 word32 = fromIntegral . fromEnum

--- a/src/Cardano/Address/Style/Icarus.hs
+++ b/src/Cardano/Address/Style/Icarus.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -19,15 +21,13 @@
 
 module Cardano.Address.Style.Icarus
     ( -- * Types
-      Icarus (..)
+      Icarus
+    , getKey
 
       -- * Generation
     , unsafeGenerateKeyFromHardwareLedger
     , unsafeGenerateKeyFromSeed
     , minSeedLengthBytes
-
-      -- * Helpers
-    , publicKey
     ) where
 
 import Prelude
@@ -47,11 +47,9 @@ import Cardano.Address.Derivation
     , Index
     , SoftDerivation (..)
     , XPrv
-    , XPub
     , deriveXPrv
     , deriveXPub
     , generateNew
-    , toXPub
     , xprvFromBytes
     )
 import Cardano.Mnemonic
@@ -103,6 +101,7 @@ newtype Icarus (depth :: Depth) key =
     Icarus { getKey :: key }
     deriving stock (Generic, Show, Eq)
 
+deriving instance (Functor (Icarus depth))
 instance (NFData key) => NFData (Icarus depth key)
 
 instance GenMasterKey Icarus where
@@ -323,6 +322,3 @@ unsafeGenerateKeyFromSeed (SomeMnemonic mw) =
             (BA.length seed >= minSeedLengthBytes && BA.length seed <= 255)
             seed
     in Icarus $ generateNew seedValidated (mempty :: ScrubbedBytes)
-
-publicKey :: Icarus depth1 XPrv -> Icarus depth2 XPub
-publicKey (Icarus k) = Icarus $ toXPub k

--- a/src/Cardano/Address/Style/Icarus.hs
+++ b/src/Cardano/Address/Style/Icarus.hs
@@ -40,33 +40,28 @@ import Cardano.Address
     )
 import Cardano.Address.Derivation
     ( Depth (..)
+    , DerivationScheme (..)
     , DerivationType (..)
     , GenMasterKey (..)
     , HardDerivation (..)
-    , Index (..)
+    , Index
     , SoftDerivation (..)
-    )
-import Cardano.Crypto.Wallet
-    ( DerivationScheme (..)
     , XPrv
     , XPub
     , deriveXPrv
     , deriveXPub
     , generateNew
     , toXPub
-    , xPrvChangePass
-    , xprv
+    , xprvFromBytes
     )
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToBytes, mnemonicToEntropy, mnemonicToText )
 import Control.Arrow
-    ( first, left )
+    ( first )
 import Control.DeepSeq
     ( NFData )
 import Control.Exception.Base
     ( assert )
-import Crypto.Error
-    ( eitherCryptoError )
 import Crypto.Hash.Algorithms
     ( SHA256 (..), SHA512 (..) )
 import Crypto.MAC.HMAC
@@ -87,7 +82,6 @@ import GHC.Generics
     ( Generic )
 
 import qualified Cardano.Codec.Cbor as CBOR
-import qualified Crypto.ECC.Edwards25519 as Ed25519
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -120,32 +114,36 @@ instance HardDerivation Icarus where
     type AccountIndexDerivationType Icarus = 'Hardened
     type AddressIndexDerivationType Icarus = 'Soft
 
-    deriveAccountPrivateKey pwd (Icarus rootXPrv) (Index accIx) =
+    deriveAccountPrivateKey (Icarus rootXPrv) accIx =
         let
+            purposeIx =
+                toEnum @(Index 'Hardened _) $ fromEnum purposeIndex
+            coinTypeIx =
+                toEnum @(Index 'Hardened _) $ fromEnum coinTypeIndex
             purposeXPrv = -- lvl1 derivation; hardened derivation of purpose'
-                deriveXPrv DerivationScheme2 pwd rootXPrv purposeIndex
+                deriveXPrv DerivationScheme2 rootXPrv purposeIx
             coinTypeXPrv = -- lvl2 derivation; hardened derivation of coin_type'
-                deriveXPrv DerivationScheme2 pwd purposeXPrv coinTypeIndex
+                deriveXPrv DerivationScheme2 purposeXPrv coinTypeIx
             acctXPrv = -- lvl3 derivation; hardened derivation of account' index
-                deriveXPrv DerivationScheme2 pwd coinTypeXPrv accIx
+                deriveXPrv DerivationScheme2 coinTypeXPrv accIx
         in
             Icarus acctXPrv
 
-    deriveAddressPrivateKey pwd (Icarus accXPrv) accountingStyle (Index addrIx) =
+    deriveAddressPrivateKey (Icarus accXPrv) accountingStyle addrIx =
         let
             changeCode =
-                fromIntegral $ fromEnum accountingStyle
+                toEnum @(Index 'Soft _) $ fromEnum accountingStyle
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
-                deriveXPrv DerivationScheme2 pwd accXPrv changeCode
+                deriveXPrv DerivationScheme2 accXPrv changeCode
             addrXPrv = -- lvl5 derivation; soft derivation of address index
-                deriveXPrv DerivationScheme2 pwd changeXPrv addrIx
+                deriveXPrv DerivationScheme2 changeXPrv addrIx
         in
             Icarus addrXPrv
 
 instance SoftDerivation Icarus where
-    deriveAddressPublicKey (Icarus accXPub) accountingStyle (Index addrIx) =
+    deriveAddressPublicKey (Icarus accXPub) accountingStyle addrIx =
         fromMaybe errWrongIndex $ do
-            let changeCode = fromIntegral $ fromEnum accountingStyle
+            let changeCode = toEnum @(Index 'Soft _) $ fromEnum accountingStyle
             changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
                 deriveXPub DerivationScheme2 accXPub changeCode
             addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain
@@ -216,10 +214,8 @@ minSeedLengthBytes = 16
 unsafeGenerateKeyFromHardwareLedger
     :: SomeMnemonic
         -- ^ The root mnemonic
-    -> ScrubbedBytes
-        -- ^ Master encryption passphrase
     -> Icarus 'RootK XPrv
-unsafeGenerateKeyFromHardwareLedger (SomeMnemonic mw) pwd = unsafeFromRight $ do
+unsafeGenerateKeyFromHardwareLedger (SomeMnemonic mw) = unsafeFromRight $ do
     let seed = pbkdf2HmacSha512
             $ T.encodeUtf8
             $ T.intercalate " "
@@ -231,10 +227,9 @@ unsafeGenerateKeyFromHardwareLedger (SomeMnemonic mw) pwd = unsafeFromRight $ do
     -- of the root private key itself.
     let cc = hmacSha256 (BS.pack [1] <> seed)
     let (iL, iR) = first pruneBuffer $ hashRepeatedly seed
-    pA <- ed25519ScalarMult iL
 
-    prv <- left show $ xprv $ iL <> iR <> pA <> cc
-    pure $ Icarus (xPrvChangePass (mempty :: ByteString) pwd prv)
+    prv <- maybe (Left "invalid xprv") pure $ xprvFromBytes $ iL <> iR <> cc
+    pure $ Icarus prv
   where
     -- Errors yielded in the body of 'unsafeGenerateKeyFromHardwareLedger' are
     -- programmer errors (out-of-range byte buffer access or, invalid length for
@@ -293,11 +288,6 @@ unsafeGenerateKeyFromHardwareLedger (SomeMnemonic mw) pwd = unsafeFromRight $ do
         in
             (firstPruned `BS.cons` BS.snoc rest' lastPruned)
 
-    ed25519ScalarMult :: ByteString -> Either String ByteString
-    ed25519ScalarMult bytes = do
-        scalar <- left show $ eitherCryptoError $ Ed25519.scalarDecodeLong bytes
-        pure $ Ed25519.pointEncode $ Ed25519.toPoint scalar
-
     -- As described in [BIP 0039 - From Mnemonic to Seed](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed)
     pbkdf2HmacSha512 :: ByteString -> ByteString
     pbkdf2HmacSha512 bytes = PBKDF2.generate
@@ -325,16 +315,14 @@ unsafeGenerateKeyFromHardwareLedger (SomeMnemonic mw) pwd = unsafeFromRight $ do
 unsafeGenerateKeyFromSeed
     :: SomeMnemonic
         -- ^ The root mnemonic
-    -> ScrubbedBytes
-        -- ^ Master encryption passphrase
     -> Icarus depth XPrv
-unsafeGenerateKeyFromSeed (SomeMnemonic mw) pwd =
+unsafeGenerateKeyFromSeed (SomeMnemonic mw) =
     let
         seed  = entropyToBytes $ mnemonicToEntropy mw
         seedValidated = assert
             (BA.length seed >= minSeedLengthBytes && BA.length seed <= 255)
             seed
-    in Icarus $ generateNew seedValidated (mempty :: ByteString) pwd
+    in Icarus $ generateNew seedValidated (mempty :: ScrubbedBytes)
 
 publicKey :: Icarus depth1 XPrv -> Icarus depth2 XPub
 publicKey (Icarus k) = Icarus $ toXPub k

--- a/test/Cardano/Address/DerivationSpec.hs
+++ b/test/Cardano/Address/DerivationSpec.hs
@@ -15,7 +15,7 @@ module Cardano.Address.DerivationSpec
 import Prelude
 
 import Cardano.Address.Derivation
-    ( Depth (..), DerivationType (..), Index, getIndex )
+    ( Depth (..), DerivationType (..), Index )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
@@ -62,8 +62,8 @@ prop_predMinBoundSoftIx = expectFailure $
 
 prop_roundtripEnumIndexHard :: Index 'WholeDomain 'AccountK -> Property
 prop_roundtripEnumIndexHard ix =
-    (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum . getIndex) ix === ix
+    (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum) ix === ix
 
 prop_roundtripEnumIndexSoft :: Index 'Soft 'AddressK -> Property
 prop_roundtripEnumIndexSoft ix =
-    (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum . getIndex) ix === ix
+    (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum) ix === ix

--- a/test/Cardano/Address/Style/ByronSpec.hs
+++ b/test/Cardano/Address/Style/ByronSpec.hs
@@ -167,9 +167,9 @@ defMnemonic =
 
 -- | Get a private key from a hex string, without error checking.
 xprv16 :: ByteString -> Byron 'RootK XPrv
-xprv16 hex = Byron k () (error "passphrase not used for tests")
+xprv16 hex = mkByronKeyFromMasterKey prv
   where
-    Just k = (xprvFromBytes <=< fromHexText) hex
+    Just prv = (xprvFromBytes <=< fromHexText) hex
     fromHexText :: ByteString -> Maybe ByteString
     fromHexText = either (const Nothing) Just . convertFromBase Base16
 

--- a/test/Cardano/Address/Style/ByronSpec.hs
+++ b/test/Cardano/Address/Style/ByronSpec.hs
@@ -23,7 +23,9 @@ import Cardano.Address.Derivation
     , Depth (..)
     , DerivationType (..)
     , HardDerivation (..)
-    , Index (..)
+    , Index
+    , XPrv
+    , xprvFromBytes
     )
 import Cardano.Address.Style.Byron
     ( Byron (..)
@@ -32,8 +34,6 @@ import Cardano.Address.Style.Byron
     , unsafeGenerateKeyFromSeed
     , unsafeMkByronKeyFromMasterKey
     )
-import Cardano.Crypto.Wallet
-    ( XPrv, xprv )
 import Cardano.Mnemonic
     ( SomeMnemonic (..) )
 import Control.Monad
@@ -75,15 +75,14 @@ spec = do
 
 prop_keyDerivationFromSeedUnsafe
     :: SomeMnemonic
-    -> Passphrase
     -> Index 'WholeDomain 'AccountK
     -> Index 'WholeDomain 'AddressK
     -> Property
-prop_keyDerivationFromSeedUnsafe seed (Passphrase encPwd) accIx addrIx =
+prop_keyDerivationFromSeedUnsafe seed accIx addrIx =
     rndKey `seq` property ()
   where
     rndKey :: Byron 'AddressK XPrv
-    rndKey = unsafeGenerateKeyFromSeed (accIx, addrIx) seed encPwd
+    rndKey = unsafeGenerateKeyFromSeed (accIx, addrIx) seed
 
 prop_keyDerivationFromXPrvUnsafe
     :: XPrv
@@ -98,17 +97,16 @@ prop_keyDerivationFromXPrvUnsafe masterkey accIx addrIx =
 
 prop_keyDerivationFromSeed
     :: SomeMnemonic
-    -> Passphrase
     -> AccountingStyle
     -> Index 'WholeDomain 'AccountK
     -> Index 'WholeDomain 'AddressK
     -> Property
-prop_keyDerivationFromSeed seed (Passphrase encPwd) style accIx addrIx =
+prop_keyDerivationFromSeed seed style accIx addrIx =
     addrXPrv `seq` property ()
   where
-    rootXPrv = unsafeGenerateKeyFromSeed () seed encPwd :: Byron 'RootK XPrv
-    accXPrv = deriveAccountPrivateKey encPwd rootXPrv accIx
-    addrXPrv = deriveAddressPrivateKey encPwd accXPrv style addrIx
+    rootXPrv = unsafeGenerateKeyFromSeed () seed :: Byron 'RootK XPrv
+    accXPrv = deriveAccountPrivateKey rootXPrv accIx
+    addrXPrv = deriveAddressPrivateKey accXPrv style addrIx
 
 prop_keyDerivationFromXPrv
     :: XPrv
@@ -119,9 +117,9 @@ prop_keyDerivationFromXPrv
 prop_keyDerivationFromXPrv masterkey style accIx addrIx =
     addrXPrv `seq` property ()
   where
-    rootXPrv@(Byron _ _ encPwd) = mkByronKeyFromMasterKey masterkey :: Byron 'RootK XPrv
-    accXPrv = deriveAccountPrivateKey encPwd rootXPrv accIx
-    addrXPrv = deriveAddressPrivateKey encPwd accXPrv style addrIx
+    rootXPrv = mkByronKeyFromMasterKey masterkey :: Byron 'RootK XPrv
+    accXPrv  = deriveAccountPrivateKey rootXPrv accIx
+    addrXPrv = deriveAddressPrivateKey accXPrv style addrIx
 
 {-------------------------------------------------------------------------------
                                   Golden tests
@@ -132,46 +130,29 @@ goldenSpec = describe "Golden tests" $ do
     it "unsafeGenerateKeyFromSeed - no passphrase" $
         generateTest generateTest1
 
-    it "unsafeGenerateKeyFromSeed - with passphrase" $
-        generateTest generateTest2
-
 {-------------------------------------------------------------------------------
                       Golden tests for generateKeyFromSeed
 -------------------------------------------------------------------------------}
 
 data GenerateKeyFromSeed = GenerateKeyFromSeed
     { mnem :: [Text]
-    , pwd :: Passphrase
     , rootKey :: Byron 'RootK XPrv
     }
 
 generateTest :: GenerateKeyFromSeed -> Expectation
-generateTest (GenerateKeyFromSeed mnemonic (Passphrase pwdEnc) rootXPrv)  =
+generateTest (GenerateKeyFromSeed mnemonic rootXPrv)  =
     getKey masterKey `shouldBe` getKey rootXPrv
   where
     mw = SomeMnemonic $ unsafeMkMnemonic @12 mnemonic
-    masterKey = unsafeGenerateKeyFromSeed () mw pwdEnc :: Byron 'RootK XPrv
+    masterKey = unsafeGenerateKeyFromSeed () mw  :: Byron 'RootK XPrv
 
 generateTest1 :: GenerateKeyFromSeed
 generateTest1 = GenerateKeyFromSeed
     { mnem = defMnemonic
-    , pwd = pp ""
     , rootKey = xprv16
-        "b84d0b6db447911a98a3ade98145c0e8323e106f07bc17a99c2104c2688bb752831090\
-        \2a3cec7e262ded6a4369ec1f48966a6b48b1ee90aa00e61b95417949f81258854ab44b\
-        \0cfda59bd68fbd87f280841a390068049df0f8a903c94ba65b7aa4762129a6c83acfda\
-        \5b257eaeb73ec5fee1518b6674fdc7891fe23f06174421"
-    }
-
-generateTest2 :: GenerateKeyFromSeed
-generateTest2 = GenerateKeyFromSeed
-    { mnem = defMnemonic
-    , pwd = pp "4a87f05fe25a57c96ff5221863e61b91bcca566b853b616f55e5d2c18caa1a4c"
-    , rootKey = xprv16
-        "b842ae13cbb31b7d96910472bbed5c8729c764d66af81b48120a6a583eae55faf78c247\
-        \65e0c9826f4d095f3e6addb4bda68df322b220d3c08b8a5b414232d101258854ab44b0c\
-        \fda59bd68fbd87f280841a390068049df0f8a903c94ba65b7aa4762129a6c83acfda5b2\
-        \57eaeb73ec5fee1518b6674fdc7891fe23f06174421"
+        "b84d0b6db447911a98a3ade98145c0e8323e106f07bc17a99c2104c2688bb752\
+        \8310902a3cec7e262ded6a4369ec1f48966a6b48b1ee90aa00e61b95417949f8\
+        \a4762129a6c83acfda5b257eaeb73ec5fee1518b6674fdc7891fe23f06174421"
     }
 
 -- | This is the mnemonic that provides the 'Default' instance in cardano-sl
@@ -188,15 +169,9 @@ defMnemonic =
 xprv16 :: ByteString -> Byron 'RootK XPrv
 xprv16 hex = Byron k () (error "passphrase not used for tests")
   where
-    Right k = xprvFromText hex
-    xprvFromText = xprv <=< fromHexText
-    fromHexText :: ByteString -> Either String ByteString
-    fromHexText = convertFromBase Base16
-
--- | Get a passphrase from a hex string, without error checking
-pp :: ByteString -> Passphrase
-pp hex = Passphrase b
-    where Right b = convertFromBase Base16 hex
+    Just k = (xprvFromBytes <=< fromHexText) hex
+    fromHexText :: ByteString -> Maybe ByteString
+    fromHexText = either (const Nothing) Just . convertFromBase Base16
 
 {-------------------------------------------------------------------------------
                              Arbitrary Instances

--- a/test/Cardano/Address/Style/IcarusSpec.hs
+++ b/test/Cardano/Address/Style/IcarusSpec.hs
@@ -3,14 +3,11 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Address.Style.IcarusSpec
     ( spec
@@ -25,18 +22,16 @@ import Cardano.Address.Derivation
     , Depth (..)
     , DerivationType (..)
     , HardDerivation (..)
-    , Index (..)
+    , Index
     , SoftDerivation (..)
+    , XPrv
     )
 import Cardano.Address.Style.Icarus
     ( Icarus (..)
-    , minSeedLengthBytes
     , publicKey
     , unsafeGenerateKeyFromHardwareLedger
     , unsafeGenerateKeyFromSeed
     )
-import Cardano.Crypto.Wallet
-    ( XPrv )
 import Cardano.Mnemonic
     ( ConsistentEntropy
     , EntropySize
@@ -46,8 +41,6 @@ import Cardano.Mnemonic
     )
 import Control.Monad
     ( forM_ )
-import Data.ByteArray
-    ( ByteArrayAccess, ScrubbedBytes )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Text
@@ -57,10 +50,8 @@ import Test.Arbitrary
 import Test.Hspec
     ( Spec, describe, it, shouldBe )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, choose, property, vector, (===) )
+    ( Property, property, (===) )
 
-import qualified Data.ByteArray as BA
-import qualified Data.ByteString as BS
 import qualified Data.Text as T
 
 spec :: Spec
@@ -105,7 +96,7 @@ spec = do
             "Ae2tdPwUPEZFJtMH1m5HvsaQZrmgLcVcyuk5TxYtdRHZFo8yV7yEnnJyqTs"
 
     describe "Hardware Ledger" $ do
-        goldenHardwareLedger @12 (Passphrase mempty)
+        goldenHardwareLedger @12
             [ "struggle", "section", "scissors", "siren", "garbage", "yellow"
             , "maximum", "finger", "duty", "require", "mule", "earn"
             ]
@@ -121,7 +112,7 @@ spec = do
             , "Ae2tdPwUPEZHRMjjXMT2icJXp5h2k2j3Ph6dB5iGRashA2QxHLgFZbHzdms"
             ]
 
-        goldenHardwareLedger @18 (Passphrase mempty)
+        goldenHardwareLedger @18
             [ "vague" , "wrist" , "poet" , "crazy" , "danger" , "dinner"
             , "grace" , "home" , "naive" , "unfold" , "april" , "exile"
             , "relief" , "rifle" , "ranch" , "tone" , "betray" , "wrong"
@@ -138,7 +129,7 @@ spec = do
             , "Ae2tdPwUPEYvq2fnzqs9EWxFF2j87nZzBAZZ7y3qoj5oTce1ZGvsc4potp3"
             ]
 
-        goldenHardwareLedger @24 (Passphrase mempty)
+        goldenHardwareLedger @24
             [ "recall" , "grace" , "sport" , "punch" , "exhibit" , "mad"
             , "harbor" , "stand" , "obey" , "short" , "width" , "stem"
             , "awkward" , "used" , "stairs" , "wool" , "ugly" , "trap"
@@ -154,24 +145,6 @@ spec = do
             , "Ae2tdPwUPEZ4K16qFm6qVRWTEGpq5TJiyt8ZojmRANTSpPDAWZuH2Ge85uB"
             , "Ae2tdPwUPEZMMYd8JP9F16HJgCsDsPjUoERWoFzZugN4mNjhR9ZnFwPonCs"
             , "Ae2tdPwUPEZ3anXo172NFuumSGjrvbk1pHK9LiF82nGmPKC52NMYR77V2dM"
-            ]
-
-        goldenHardwareLedger @24 (Passphrase "very secure passphrase")
-            [ "burden", "destroy", "client", "air", "agent", "episode"
-            , "horror", "orient", "scrap", "car", "point", "easy"
-            , "local", "primary", "grunt", "seminar", "goose", "spin"
-            , "charge", "olive", "angry", "hour", "start", "shop"
-            ]
-            [ "Ae2tdPwUPEZHiTeWAxzLFm5qYAGqLLwZ35huQJ7Dg5fJ4SN97d1QwhsuDrG"
-            , "Ae2tdPwUPEZBD4rL6Msf2DdthRYLuYFxeG1hawjqtKYzMw2USoFQ9VmuU9C"
-            , "Ae2tdPwUPEZH5dhpwZHFVsemEpvgMMpSboyrM1PEThh6MwQTCXG2FoCCPHR"
-            , "Ae2tdPwUPEYz1AhmV59DNL92P8rrU8Wa9x9ttPTUoBSCvnEoJacmZbTahRu"
-            , "Ae2tdPwUPEZKqr3xfBLtQuhwNqtnFLq7ttptUxwyatoFF1ofgSaUTFmqiBb"
-            , "Ae2tdPwUPEZL1exTaCW3yfMj8eosgg7zcG35qfTQFyetgcJ3969agkrXXU5"
-            , "Ae2tdPwUPEZL2X1g23MKScFTvaLACCgpdWxozSjb5aXmg3YCESeiSftHyGJ"
-            , "Ae2tdPwUPEZKHqZcXY3AqLhWHzKVieBhedr7ixRmMsxsVKA1aVTEHPVK5aG"
-            , "Ae2tdPwUPEZLU4TEkPMmkT2dfQ23YyKLFWXBwuxLi4rxF4kT6najwAi6APQ"
-            , "Ae2tdPwUPEZBFKNnz2F1Bn5pLkhp2rm9byDAyW1JzN7ZUYSgRPqrH3Jgs88"
             ]
 
 {-------------------------------------------------------------------------------
@@ -195,29 +168,27 @@ spec = do
 -- For details see <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key bip-0039>
 prop_publicChildKeyDerivation
     :: SomeMnemonic
-    -> Passphrase
     -> AccountingStyle
     -> Index 'Soft 'AddressK
     -> Property
-prop_publicChildKeyDerivation seed (Passphrase encPwd) cc ix =
+prop_publicChildKeyDerivation seed cc ix =
     addrXPub1 === addrXPub2
   where
-    accXPrv = unsafeGenerateKeyFromSeed seed encPwd :: Icarus 'AccountK XPrv
+    accXPrv = unsafeGenerateKeyFromSeed seed :: Icarus 'AccountK XPrv
     -- N(CKDpriv((kpar, cpar), i))
-    addrXPub1 = publicKey $ deriveAddressPrivateKey encPwd accXPrv cc ix
+    addrXPub1 = publicKey $ deriveAddressPrivateKey accXPrv cc ix
     -- CKDpub(N(kpar, cpar), i)
     addrXPub2 = deriveAddressPublicKey (publicKey accXPrv) cc ix
 
 prop_accountKeyDerivation
     :: SomeMnemonic
-    -> Passphrase
     -> Index 'Hardened 'AccountK
     -> Property
-prop_accountKeyDerivation seed (Passphrase encPwd) ix =
+prop_accountKeyDerivation seed ix =
     accXPrv `seq` property () -- NOTE Making sure this doesn't throw
   where
-    rootXPrv = unsafeGenerateKeyFromSeed seed encPwd :: Icarus 'RootK XPrv
-    accXPrv = deriveAccountPrivateKey encPwd rootXPrv ix
+    rootXPrv = unsafeGenerateKeyFromSeed seed :: Icarus 'RootK XPrv
+    accXPrv = deriveAccountPrivateKey rootXPrv ix
 
 {-------------------------------------------------------------------------------
                                Golden Tests
@@ -237,10 +208,9 @@ goldenAddressGeneration
     :: GoldenAddressGeneration
     -> Spec
 goldenAddressGeneration test = it title $ do
-    let encPwd = mempty
-    let rootXPrv = unsafeGenerateKeyFromSeed goldSeed encPwd
-    let acctXPrv = deriveAccountPrivateKey encPwd rootXPrv goldAcctIx
-    let addrXPrv = deriveAddressPrivateKey encPwd acctXPrv goldAcctStyle goldAddrIx
+    let rootXPrv = unsafeGenerateKeyFromSeed goldSeed
+    let acctXPrv = deriveAccountPrivateKey rootXPrv goldAcctIx
+    let addrXPrv = deriveAddressPrivateKey acctXPrv goldAcctStyle goldAddrIx
     base58 (paymentAddress mainnetDiscriminant $ publicKey addrXPrv)
         `shouldBe` goldAddr
   where
@@ -273,19 +243,17 @@ goldenHardwareLedger
         ( ConsistentEntropy ent mw csz
         , EntropySize mw ~ ent
         )
-    => Passphrase
-        -- ^ An encryption passphrase
-    -> [Text]
+    => [Text]
         -- ^ 24-word mnemonic
     -> [Text]
         -- ^ Some addresses, starting at index 0
     -> Spec
-goldenHardwareLedger (Passphrase encPwd) sentence addrs =
+goldenHardwareLedger sentence addrs =
     it title $ do
         let Right mnemonic = SomeMnemonic <$> mkMnemonic @mw sentence
-        let rootXPrv = unsafeGenerateKeyFromHardwareLedger mnemonic encPwd
-        let acctXPrv = deriveAccountPrivateKey encPwd rootXPrv minBound
-        let deriveAddr = deriveAddressPrivateKey encPwd acctXPrv UTxOExternal
+        let rootXPrv = unsafeGenerateKeyFromHardwareLedger mnemonic
+        let acctXPrv = deriveAccountPrivateKey rootXPrv minBound
+        let deriveAddr = deriveAddressPrivateKey acctXPrv UTxOExternal
 
         forM_ (zip [0..] addrs) $ \(ix, addr) -> do
             let addrXPrv = deriveAddr (toEnum ix)
@@ -295,17 +263,3 @@ goldenHardwareLedger (Passphrase encPwd) sentence addrs =
     title = T.unpack
         $ T.unwords
         $ take 3 sentence ++ [ "..." ] ++ drop (length sentence - 3) sentence
-
-{-------------------------------------------------------------------------------
-                             Arbitrary Instances
--------------------------------------------------------------------------------}
-
-newtype Passphrase = Passphrase ScrubbedBytes
-    deriving stock (Eq, Show)
-    deriving newtype (ByteArrayAccess)
-
-instance Arbitrary Passphrase where
-    arbitrary = do
-        n <- choose (minSeedLengthBytes, 64)
-        bytes <- BS.pack <$> vector n
-        return $ Passphrase $ BA.convert bytes

--- a/test/Cardano/Address/Style/IcarusSpec.hs
+++ b/test/Cardano/Address/Style/IcarusSpec.hs
@@ -25,10 +25,10 @@ import Cardano.Address.Derivation
     , Index
     , SoftDerivation (..)
     , XPrv
+    , toXPub
     )
 import Cardano.Address.Style.Icarus
     ( Icarus (..)
-    , publicKey
     , unsafeGenerateKeyFromHardwareLedger
     , unsafeGenerateKeyFromSeed
     )
@@ -176,9 +176,9 @@ prop_publicChildKeyDerivation seed cc ix =
   where
     accXPrv = unsafeGenerateKeyFromSeed seed :: Icarus 'AccountK XPrv
     -- N(CKDpriv((kpar, cpar), i))
-    addrXPub1 = publicKey $ deriveAddressPrivateKey accXPrv cc ix
+    addrXPub1 = toXPub <$> deriveAddressPrivateKey accXPrv cc ix
     -- CKDpub(N(kpar, cpar), i)
-    addrXPub2 = deriveAddressPublicKey (publicKey accXPrv) cc ix
+    addrXPub2 = deriveAddressPublicKey (toXPub <$> accXPrv) cc ix
 
 prop_accountKeyDerivation
     :: SomeMnemonic
@@ -211,7 +211,7 @@ goldenAddressGeneration test = it title $ do
     let rootXPrv = unsafeGenerateKeyFromSeed goldSeed
     let acctXPrv = deriveAccountPrivateKey rootXPrv goldAcctIx
     let addrXPrv = deriveAddressPrivateKey acctXPrv goldAcctStyle goldAddrIx
-    base58 (paymentAddress mainnetDiscriminant $ publicKey addrXPrv)
+    base58 (paymentAddress mainnetDiscriminant $ toXPub <$> addrXPrv)
         `shouldBe` goldAddr
   where
     GoldenAddressGeneration
@@ -257,7 +257,7 @@ goldenHardwareLedger sentence addrs =
 
         forM_ (zip [0..] addrs) $ \(ix, addr) -> do
             let addrXPrv = deriveAddr (toEnum ix)
-            base58 (paymentAddress mainnetDiscriminant $ publicKey addrXPrv)
+            base58 (paymentAddress mainnetDiscriminant $ toXPub <$> addrXPrv)
                 `shouldBe` addr
   where
     title = T.unpack

--- a/test/Cardano/AddressSpec.hs
+++ b/test/Cardano/AddressSpec.hs
@@ -18,13 +18,11 @@ import Cardano.Address
     , fromBech32
     )
 import Cardano.Address.Derivation
-    ( Depth (..) )
+    ( Depth (..), XPub )
 import Cardano.Address.Style.Byron
     ( Byron )
 import Cardano.Address.Style.Icarus
     ( Icarus )
-import Cardano.Crypto.Wallet
-    ( XPub )
 import Data.Function
     ( (&) )
 import Data.Text

--- a/test/Cardano/Codec/CborSpec.hs
+++ b/test/Cardano/Codec/CborSpec.hs
@@ -17,7 +17,7 @@ module Cardano.Codec.CborSpec
 import Prelude
 
 import Cardano.Address.Derivation
-    ( Depth (..) )
+    ( Depth (..), XPrv )
 import Cardano.Address.Style.Byron
     ( Byron (..), unsafeGenerateKeyFromSeed )
 import Cardano.Codec.Cbor
@@ -31,8 +31,6 @@ import Cardano.Codec.Cbor
     , toLazyByteString
     , unsafeDeserialiseCbor
     )
-import Cardano.Crypto.Wallet
-    ( XPrv )
 import Cardano.Mnemonic
     ( mkSomeMnemonic )
 import Data.ByteArray
@@ -144,7 +142,7 @@ decodeDerivationPathTest DecodeDerivationPath{..} =
         BL.fromStrict (unsafeFromHex addr)
     decoded = deserialiseCbor (decodeAddressDerivationPath pwd) payload
     Right seed = mkSomeMnemonic @'[12] mnem
-    key = unsafeGenerateKeyFromSeed () seed mempty :: Byron 'RootK XPrv
+    key = unsafeGenerateKeyFromSeed () seed :: Byron 'RootK XPrv
     pwd = payloadPassphrase key
 
 {-------------------------------------------------------------------------------

--- a/test/Test/Arbitrary.hs
+++ b/test/Test/Arbitrary.hs
@@ -28,6 +28,7 @@ import Cardano.Address.Derivation
     , XPub
     , generate
     , generateNew
+    , toXPub
     , xprvToBytes
     )
 import Cardano.Address.Style.Byron
@@ -142,13 +143,13 @@ instance Arbitrary (Byron 'AddressK XPub) where
     arbitrary = do
         mw <- SomeMnemonic <$> genMnemonic @12
         path <- (,) <$> arbitrary <*> arbitrary
-        pure $ Byron.publicKey $ Byron.unsafeGenerateKeyFromSeed path mw
+        pure $ toXPub <$> Byron.unsafeGenerateKeyFromSeed path mw
 
 instance Arbitrary (Icarus 'AddressK XPub) where
     shrink _ = []
     arbitrary = do
         mw <- SomeMnemonic <$> genMnemonic @15
-        pure $ Icarus.publicKey $ Icarus.unsafeGenerateKeyFromSeed mw
+        pure $ toXPub <$> Icarus.unsafeGenerateKeyFromSeed mw
 
 instance Arbitrary NetworkDiscriminant where
     arbitrary = oneof


### PR DESCRIPTION
- 25857dbfa1b93b28203de29b065d2282d9725838
  :round_pushpin: **provide thin wrapper on top of crypto primitives**
  The cardano-crypto is quite 'old' and has a lot of legacy inherited from past decision. One of them
was the decision of keeping every key 'XPrv' encrypted in-memory which has been said useless by our
cryptographers quite a few times.
It is necessary to encrypt the key when storing it into a more persistent location, but this isn't a
concern for this library. We can therefore simplify quite a few interfaces by removing the question
of encryption passphrases altogether.

Another annoyance of 'cardano-crypto' is that it internally stores and represent XPrv as a combination of:
  prv <> pub <> cc, and all conversion functions are made to and from this internal representation.
This is not very handy for in practice, we are often interested in either prv <> cc or pub <> cc. Thus,
our wrapper provide the necessary bits for correctly handling this conversion.

- 9eb52c494a712822d7495a3e3bf23f58ed3a26ce
  :round_pushpin: **add custom rule to hlint to warn developers if using functions from 'Cardano.Crypto.Wallet' directly**
  
- ed5229e24d9dca7d6b32f7b377708d804a012e9d
  :round_pushpin: **further small documentation improvements in Cardano.Address.Derivation**
  
- a19d6a5eb145ce3d0535f9ef5dfa9f1953d56ac7
  :round_pushpin: **Make 'Byron' and 'Icarus' functors and hide constructors**
  This makes for a slightly better public API, and allows for better maintainability. Users of the modules are
forced to use the provided API instead of constructing the types themselves.