### PR TITLE
Rework documentation and public interfaces for 'Cardano.Address.Style.*'

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -43,7 +43,6 @@ library:
   - fmt
   - memory
   - text
-  - transformers
 
 tests:
   unit:

--- a/src/Cardano/Address.hs
+++ b/src/Cardano/Address.hs
@@ -43,8 +43,6 @@ import Control.DeepSeq
     ( NFData )
 import Control.Monad
     ( (<=<) )
-import Data.ByteArray
-    ( ByteArrayAccess )
 import Data.ByteString
     ( ByteString )
 import Data.ByteString.Base58
@@ -67,7 +65,6 @@ import qualified Data.Text.Encoding as T
 newtype Address = Address
     { unAddress :: ByteString
     } deriving stock (Generic, Show, Eq, Ord)
-      deriving newtype (ByteArrayAccess)
 instance NFData Address
 
 -- Unsafe constructor for easily lifting bytes inside an 'Address'.
@@ -158,7 +155,7 @@ testnetDiscriminant = RequiresMagic testnetMagic
 --
 -- @since 1.0.0
 newtype ProtocolMagic
-    = ProtocolMagic { getProtocolMagic :: Word32 }
+    = ProtocolMagic Word32
     deriving (Generic, Show, Eq)
 instance NFData ProtocolMagic
 

--- a/src/Cardano/Address/Derivation.hs
+++ b/src/Cardano/Address/Derivation.hs
@@ -76,6 +76,8 @@ import GHC.Generics
     ( Generic )
 import Crypto.Error
     ( eitherCryptoError )
+import Cardano.Mnemonic
+    ( SomeMnemonic )
 
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Data.ByteString as BS
@@ -345,6 +347,7 @@ data DerivationType = Hardened | Soft | WholeDomain
 class HardDerivation (key :: Depth -> * -> *) where
     type AccountIndexDerivationType key :: DerivationType
     type AddressIndexDerivationType key :: DerivationType
+    type WithAccountStyle key :: *
 
     -- | Derives account private key from the given root private key, using
     -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
@@ -363,7 +366,7 @@ class HardDerivation (key :: Depth -> * -> *) where
     -- @since 1.0.0
     deriveAddressPrivateKey
         :: key 'AccountK XPrv
-        -> AccountingStyle
+        -> WithAccountStyle key
         -> Index (AddressIndexDerivationType key) 'AddressK
         -> key 'AddressK XPrv
 
@@ -387,9 +390,16 @@ class HardDerivation key => SoftDerivation (key :: Depth -> * -> *) where
 --
 -- @since 1.0.0
 class GenMasterKey (key :: Depth -> * -> *) where
-    type GenMasterKeyFrom key :: *
+    type SecondFactor key :: *
 
-    -- | Generate a root key from a corresponding seed.
+    -- | Generate a root key from a corresponding mnemonic.
     --
     -- @since 1.0.0
-    genMasterKey :: GenMasterKeyFrom key -> key 'RootK XPrv
+    genMasterKeyFromMnemonic
+        :: SomeMnemonic -> SecondFactor key -> key 'RootK XPrv
+
+    -- | Generate a root key from a corresponding root 'XPrv'
+    --
+    -- @since 1.0.0
+    genMasterKeyFromXPrv
+        :: XPrv -> key 'RootK XPrv

--- a/src/Cardano/Address/Style/Byron.hs
+++ b/src/Cardano/Address/Style/Byron.hs
@@ -140,7 +140,7 @@ deriving instance (Functor (Byron depth))
 -- of key this is. This is mostly for testing, in practice, seeds are used to
 -- represent root keys, and one should 'genMasterKeyFromXPrv'
 --
--- The first argument is a type-family 'DerivationPath' and its type depend on
+-- The first argument is a type-family 'DerivationPath' and its type depends on
 -- the 'depth' of the key.
 --
 -- __examples:__

--- a/src/Cardano/Address/Style/Byron.hs
+++ b/src/Cardano/Address/Style/Byron.hs
@@ -11,6 +11,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_HADDOCK prune #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -28,12 +30,10 @@ module Cardano.Address.Style.Byron
     , payloadPassphrase
     , derivationPath
     , getKey
+    , liftXPrv
 
-      -- * Generation
-    , unsafeGenerateKeyFromSeed
+      -- Internal
     , minSeedLengthBytes
-    , mkByronKeyFromMasterKey
-    , unsafeMkByronKeyFromMasterKey
     ) where
 
 import Prelude
@@ -103,6 +103,21 @@ deriving instance (Show key, Show (DerivationPath depth)) => Show (Byron depth k
 deriving instance (Eq key, Eq (DerivationPath depth)) => Eq (Byron depth key)
 deriving instance (Functor (Byron depth))
 
+-- | Backdoor for generating a new key from a raw XPrv.
+--
+-- Note that the @depth@ is left open so that the caller gets to decide what type
+-- of key this is. This is mostly for testing, in practice, seeds are used to
+-- represent root keys, and one should 'genMasterKeyFromXPrv'
+liftXPrv
+    :: DerivationPath depth
+    -> XPrv
+    -> Byron depth XPrv
+liftXPrv derivationPath getKey = Byron
+    { getKey
+    , derivationPath
+    , payloadPassphrase = hdPassphrase (toXPub getKey)
+    }
+
 -- | The hierarchical derivation indices for a given level/depth.
 type family DerivationPath (depth :: Depth) :: * where
     -- The root key is generated from the seed.
@@ -116,13 +131,22 @@ type family DerivationPath (depth :: Depth) :: * where
         (Index 'WholeDomain 'AccountK, Index 'WholeDomain 'AddressK)
 
 instance GenMasterKey Byron where
-    type GenMasterKeyFrom Byron = SomeMnemonic
+    type SecondFactor Byron = ()
 
-    genMasterKey = generateKeyFromSeed
+    genMasterKeyFromXPrv = liftXPrv ()
+    genMasterKeyFromMnemonic (SomeMnemonic mw) () =
+        liftXPrv () xprv
+      where
+        xprv = generate (hashSeed seedValidated)
+        seed  = entropyToBytes $ mnemonicToEntropy mw
+        seedValidated = assert
+            (BA.length seed >= minSeedLengthBytes && BA.length seed <= 255)
+            seed
 
 instance HardDerivation Byron where
     type AddressIndexDerivationType Byron = 'WholeDomain
     type AccountIndexDerivationType Byron = 'WholeDomain
+    type WithAccountStyle Byron = ()
 
     deriveAccountPrivateKey rootXPrv accIx = Byron
         { getKey = deriveXPrv DerivationScheme1 (getKey rootXPrv) accIx
@@ -130,7 +154,7 @@ instance HardDerivation Byron where
         , payloadPassphrase = payloadPassphrase rootXPrv
         }
 
-    deriveAddressPrivateKey accXPrv _accStyle addrIx = Byron
+    deriveAddressPrivateKey accXPrv () addrIx = Byron
         { getKey = deriveXPrv DerivationScheme1 (getKey accXPrv) addrIx
         , derivationPath = (derivationPath accXPrv, addrIx)
         , payloadPassphrase = payloadPassphrase accXPrv
@@ -152,40 +176,13 @@ instance PaymentAddress Byron where
                 , CBOR.encodeProtocolMagicAttr pm
                 ]
 
-{-------------------------------------------------------------------------------
-                                 Key generation
--------------------------------------------------------------------------------}
+--
+-- Internal
+--
 
 -- | The amount of entropy carried by a BIP-39 12-word mnemonic is 16 bytes.
 minSeedLengthBytes :: Int
 minSeedLengthBytes = 16
-
--- | Generate a root key from a corresponding seed.
--- The seed should be at least 16 bytes.
-generateKeyFromSeed
-    :: SomeMnemonic
-    -> Byron 'RootK XPrv
-generateKeyFromSeed = unsafeGenerateKeyFromSeed ()
-
--- | Generate a new key from seed. Note that the @depth@ is left open so that
--- the caller gets to decide what type of key this is. This is mostly for
--- testing, in practice, seeds are used to represent root keys, and one should
--- use 'generateKeyFromSeed'.
-unsafeGenerateKeyFromSeed
-    :: DerivationPath depth
-    -> SomeMnemonic
-    -> Byron depth XPrv
-unsafeGenerateKeyFromSeed derivationPath (SomeMnemonic mw) = Byron
-    { getKey = masterKey
-    , derivationPath
-    , payloadPassphrase = hdPassphrase (toXPub masterKey)
-    }
-  where
-    masterKey = generate (hashSeed seedValidated)
-    seed  = entropyToBytes $ mnemonicToEntropy mw
-    seedValidated = assert
-        (BA.length seed >= minSeedLengthBytes && BA.length seed <= 255)
-        seed
 
 -- | Hash the seed entropy (generated from mnemonic) used to initiate a HD
 -- wallet. This increases the key length to 34 bytes, selectKey is greater than the
@@ -220,26 +217,6 @@ hdPassphrase masterKey =
     (PBKDF2.Parameters 500 32)
     (xpubToBytes masterKey)
     ("address-hashing" :: ByteString)
-
-mkByronKeyFromMasterKey
-    :: XPrv
-    -> Byron 'RootK XPrv
-mkByronKeyFromMasterKey =
-    unsafeMkByronKeyFromMasterKey ()
-
-unsafeMkByronKeyFromMasterKey
-    :: DerivationPath depth
-    -> XPrv
-    -> Byron depth XPrv
-unsafeMkByronKeyFromMasterKey derivationPath masterKey = Byron
-    { getKey = masterKey
-    , derivationPath
-    , payloadPassphrase = hdPassphrase (toXPub masterKey)
-    }
-
---
--- Internal
---
 
 word32 :: Enum a => a -> Word32
 word32 = fromIntegral . fromEnum

--- a/src/Cardano/Address/Style/Icarus.hs
+++ b/src/Cardano/Address/Style/Icarus.hs
@@ -160,7 +160,7 @@ instance (NFData key) => NFData (Icarus depth key)
 -- | Unsafe backdoor for constructing an 'Icarus' key from a raw 'XPrv'. this is
 -- unsafe because it lets the caller choose the actually derivation 'depth'.
 --
--- This can be useful however when serializing / deserializing such type, or to
+-- This can be useful however when serializing / deserializing such a type, or to
 -- speed up test code (and avoid having to do needless derivations from a master
 -- key down to an address key for instance).
 --

--- a/test/Cardano/Address/DerivationSpec.hs
+++ b/test/Cardano/Address/DerivationSpec.hs
@@ -15,9 +15,20 @@ module Cardano.Address.DerivationSpec
 import Prelude
 
 import Cardano.Address.Derivation
-    ( Depth (..), DerivationType (..), Index )
+    ( Depth (..)
+    , DerivationType (..)
+    , Index
+    , xprvFromBytes
+    , xprvToBytes
+    , xpubFromBytes
+    , xpubToBytes
+    )
+import Data.ByteString
+    ( ByteString )
 import Test.Hspec
     ( Spec, describe, it )
+import Test.Hspec.QuickCheck
+    ( prop )
 import Test.QuickCheck
     ( Property, expectFailure, property, (.&&.), (===) )
 
@@ -40,9 +51,24 @@ spec = describe "Checking auxiliary address derivations types" $ do
         it "Index @'Hardened _" (property prop_roundtripEnumIndexHard)
         it "Index @'Soft _" (property prop_roundtripEnumIndexSoft)
 
+    describe "bytes roundtrips" $ do
+        prop "xpubToBytes . xpubFromBytes" $
+            prop_roundtripBytes xpubToBytes xpubFromBytes
+        prop "xprvToBytes . xprvFromBytes" $
+            prop_roundtripBytes xprvToBytes xprvFromBytes
+
 {-------------------------------------------------------------------------------
                                Properties
 -------------------------------------------------------------------------------}
+
+prop_roundtripBytes
+    :: (Eq a, Show a)
+    => (a -> ByteString)
+    -> (ByteString -> Maybe a)
+    -> a
+    -> Property
+prop_roundtripBytes encode decode a =
+    decode (encode a) === pure a
 
 prop_succMaxBoundHardIx :: Property
 prop_succMaxBoundHardIx = expectFailure $

--- a/test/Cardano/Address/Style/ByronSpec.hs
+++ b/test/Cardano/Address/Style/ByronSpec.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Cardano.Address.Style.ByronSpec
     ( spec

--- a/test/Cardano/Address/Style/ByronSpec.hs
+++ b/test/Cardano/Address/Style/ByronSpec.hs
@@ -19,21 +19,16 @@ module Cardano.Address.Style.ByronSpec
 import Prelude
 
 import Cardano.Address.Derivation
-    ( AccountingStyle
-    , Depth (..)
+    ( Depth (..)
     , DerivationType (..)
+    , GenMasterKey (..)
     , HardDerivation (..)
     , Index
     , XPrv
     , xprvFromBytes
     )
 import Cardano.Address.Style.Byron
-    ( Byron (..)
-    , minSeedLengthBytes
-    , mkByronKeyFromMasterKey
-    , unsafeGenerateKeyFromSeed
-    , unsafeMkByronKeyFromMasterKey
-    )
+    ( Byron (..), minSeedLengthBytes )
 import Cardano.Mnemonic
     ( SomeMnemonic (..) )
 import Control.Monad
@@ -64,62 +59,34 @@ spec = do
             property prop_keyDerivationFromSeed
         it "Key derivation from master key works for various indexes" $
             property prop_keyDerivationFromXPrv
-        it "Key derivation from seed works for various indexes - unsafe" $
-            property prop_keyDerivationFromSeedUnsafe
-        it "Key derivation from master key works for various indexes - unsafe" $
-            property prop_keyDerivationFromXPrvUnsafe
 
 {-------------------------------------------------------------------------------
                                Properties
 -------------------------------------------------------------------------------}
 
-prop_keyDerivationFromSeedUnsafe
-    :: SomeMnemonic
-    -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
-    -> Property
-prop_keyDerivationFromSeedUnsafe seed accIx addrIx =
-    rndKey `seq` property ()
-  where
-    rndKey :: Byron 'AddressK XPrv
-    rndKey = unsafeGenerateKeyFromSeed (accIx, addrIx) seed
-
-prop_keyDerivationFromXPrvUnsafe
-    :: XPrv
-    -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
-    -> Property
-prop_keyDerivationFromXPrvUnsafe masterkey accIx addrIx =
-    rndKey `seq` property ()
-  where
-    rndKey :: Byron 'AddressK XPrv
-    rndKey = unsafeMkByronKeyFromMasterKey (accIx, addrIx) masterkey
-
 prop_keyDerivationFromSeed
     :: SomeMnemonic
-    -> AccountingStyle
     -> Index 'WholeDomain 'AccountK
     -> Index 'WholeDomain 'AddressK
     -> Property
-prop_keyDerivationFromSeed seed style accIx addrIx =
+prop_keyDerivationFromSeed mw accIx addrIx =
     addrXPrv `seq` property ()
   where
-    rootXPrv = unsafeGenerateKeyFromSeed () seed :: Byron 'RootK XPrv
+    rootXPrv = genMasterKeyFromMnemonic mw () :: Byron 'RootK XPrv
     accXPrv = deriveAccountPrivateKey rootXPrv accIx
-    addrXPrv = deriveAddressPrivateKey accXPrv style addrIx
+    addrXPrv = deriveAddressPrivateKey accXPrv () addrIx
 
 prop_keyDerivationFromXPrv
     :: XPrv
-    -> AccountingStyle
     -> Index 'WholeDomain 'AccountK
     -> Index 'WholeDomain 'AddressK
     -> Property
-prop_keyDerivationFromXPrv masterkey style accIx addrIx =
+prop_keyDerivationFromXPrv xprv accIx addrIx =
     addrXPrv `seq` property ()
   where
-    rootXPrv = mkByronKeyFromMasterKey masterkey :: Byron 'RootK XPrv
+    rootXPrv = genMasterKeyFromXPrv xprv :: Byron 'RootK XPrv
     accXPrv  = deriveAccountPrivateKey rootXPrv accIx
-    addrXPrv = deriveAddressPrivateKey accXPrv style addrIx
+    addrXPrv = deriveAddressPrivateKey accXPrv () addrIx
 
 {-------------------------------------------------------------------------------
                                   Golden tests
@@ -144,7 +111,7 @@ generateTest (GenerateKeyFromSeed mnemonic rootXPrv)  =
     getKey masterKey `shouldBe` getKey rootXPrv
   where
     mw = SomeMnemonic $ unsafeMkMnemonic @12 mnemonic
-    masterKey = unsafeGenerateKeyFromSeed () mw  :: Byron 'RootK XPrv
+    masterKey = genMasterKeyFromMnemonic mw () :: Byron 'RootK XPrv
 
 generateTest1 :: GenerateKeyFromSeed
 generateTest1 = GenerateKeyFromSeed
@@ -167,7 +134,7 @@ defMnemonic =
 
 -- | Get a private key from a hex string, without error checking.
 xprv16 :: ByteString -> Byron 'RootK XPrv
-xprv16 hex = mkByronKeyFromMasterKey prv
+xprv16 hex = genMasterKeyFromXPrv prv
   where
     Just prv = (xprvFromBytes <=< fromHexText) hex
     fromHexText :: ByteString -> Maybe ByteString

--- a/test/Cardano/AddressSpec.hs
+++ b/test/Cardano/AddressSpec.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 module Cardano.AddressSpec
     ( spec
     ) where

--- a/test/Cardano/Codec/CborSpec.hs
+++ b/test/Cardano/Codec/CborSpec.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Cardano.Codec.CborSpec
     ( spec

--- a/test/Cardano/Codec/CborSpec.hs
+++ b/test/Cardano/Codec/CborSpec.hs
@@ -17,9 +17,9 @@ module Cardano.Codec.CborSpec
 import Prelude
 
 import Cardano.Address.Derivation
-    ( Depth (..), XPrv )
+    ( Depth (..), GenMasterKey (..), XPrv )
 import Cardano.Address.Style.Byron
-    ( Byron (..), unsafeGenerateKeyFromSeed )
+    ( Byron (..) )
 import Cardano.Codec.Cbor
     ( decodeAddressDerivationPath
     , decodeAddressPayload
@@ -141,8 +141,8 @@ decodeDerivationPathTest DecodeDerivationPath{..} =
     payload = unsafeDeserialiseCbor decodeAddressPayload $
         BL.fromStrict (unsafeFromHex addr)
     decoded = deserialiseCbor (decodeAddressDerivationPath pwd) payload
-    Right seed = mkSomeMnemonic @'[12] mnem
-    key = unsafeGenerateKeyFromSeed () seed :: Byron 'RootK XPrv
+    Right mw = mkSomeMnemonic @'[12] mnem
+    key = genMasterKeyFromMnemonic mw () :: Byron 'RootK XPrv
     pwd = payloadPassphrase key
 
 {-------------------------------------------------------------------------------

--- a/test/Test/Arbitrary.hs
+++ b/test/Test/Arbitrary.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Test.Arbitrary
     (

--- a/test/Test/Arbitrary.hs
+++ b/test/Test/Arbitrary.hs
@@ -10,9 +10,7 @@
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Test.Arbitrary
-    (
-      genMnemonic
-    , unsafeMkMnemonic
+    ( unsafeMkMnemonic
     , unsafeMkSomeMnemonicFromEntropy
     , unsafeFromHex
     ) where

--- a/test/Test/Arbitrary.hs
+++ b/test/Test/Arbitrary.hs
@@ -142,6 +142,10 @@ instance Arbitrary XPrv where
         , generate . BS.pack <$> vector 32
         ]
 
+instance Arbitrary XPub where
+    arbitrary =
+        toXPub <$> arbitrary
+
 instance Arbitrary AccountingStyle where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum

--- a/test/Test/Arbitrary.hs
+++ b/test/Test/Arbitrary.hs
@@ -18,7 +18,15 @@ module Test.Arbitrary
 import Prelude
 
 import Cardano.Address
-    ( NetworkDiscriminant (..), ProtocolMagic (..) )
+    ( NetworkDiscriminant (..)
+    , ProtocolMagic (..)
+    , mainnetDiscriminant
+    , mainnetMagic
+    , stagingDiscriminant
+    , stagingMagic
+    , testnetDiscriminant
+    , testnetMagic
+    )
 import Cardano.Address.Derivation
     ( AccountingStyle
     , Depth (..)
@@ -160,13 +168,23 @@ instance Arbitrary (Icarus 'AddressK XPub) where
 
 instance Arbitrary NetworkDiscriminant where
     arbitrary = oneof
+        -- NOTE using explicit smart-constructor as a quick-win for the coverage :)
         [ pure RequiresNoMagic
         , RequiresMagic <$> arbitrary
+        , pure mainnetDiscriminant
+        , pure stagingDiscriminant
+        , pure testnetDiscriminant
         ]
 
 instance Arbitrary ProtocolMagic where
     shrink (ProtocolMagic pm) = ProtocolMagic <$> shrink pm
-    arbitrary = ProtocolMagic <$> arbitrary
+    arbitrary = oneof
+        -- NOTE using explicit smart-constructor as a quick-win for the coverage :)
+        [ ProtocolMagic <$> arbitrary
+        , pure mainnetMagic
+        , pure stagingMagic
+        , pure testnetMagic
+        ]
 
 --
 -- Extra Instances


### PR DESCRIPTION
- 28586e73647dc5b2c10a987984761c23f9bae6bd
  :round_pushpin: **rework internals for 'Byron' and 'Icarus' to promote high-level interface more**
  This creats more consistency between both modules, and also makes for more maintainable code in the long-run. Instead of exposing and using internal functions
(even in testing), we can rely on the defined abstractions that we are also going to present users of the library.

- 4f13154c705862b0abb63aee1f4e4db782bb91aa
  :round_pushpin: **another round of revision on the documentation for 'Byron' and 'Icarus' styles**
  - Added some clear depreciation notice on 'Byron'
- Some examples of using 'GenMasterKey', 'HardDerivation' and 'PaymentAddress'
- Hide some internal type or constructs.

- ab2d8612581e189ddb23ca13e79dbcdffa5cbc18
  :round_pushpin: **cleanup unused dependencies and exports**
  
- 372483f6bfd319084a1d7b06526b62837f37f45c
  :round_pushpin: **minor tweaks for some easy-win with the code-coverage**
  
- 02dde3e9cfe1b10cf8435c2b87a1de77b3ca2c58
  :round_pushpin: **roundtrip test for xpub/xprv to and from bytes**
