### PR TITLE
distinguish between staking key and address key

### DIFF
--- a/src/Cardano/Address.hs
+++ b/src/Cardano/Address.hs
@@ -126,8 +126,8 @@ class PaymentAddress key
         :: NetworkDiscriminant key
         ->  key 'AddressK XPub
             -- ^ Payment key
-        ->  key 'AddressK XPub
-            -- ^ Staking key / Reward account
+        ->  key 'StakingK XPub
+            -- ^ Staking key
         -> Address
 
 class HasNetworkDiscriminant (key :: Depth -> * -> *) where

--- a/src/Cardano/Address/Derivation.hs
+++ b/src/Cardano/Address/Derivation.hs
@@ -262,7 +262,7 @@ generateNew seed sndFactor =
 -- are no constructors for these.
 --
 -- @since 1.0.0
-data Depth = RootK | AccountK | AddressK
+data Depth = RootK | AccountK | AddressK | StakingK
 
 -- | Marker for addresses type engaged. We want to handle three cases here.
 -- The first two are pertinent to UTxO accounting
@@ -271,11 +271,9 @@ data Depth = RootK | AccountK | AddressK
 --     targets of a given transaction
 -- (b) internal change is for addresses used to handle the change of a
 --     the transaction within a given wallet
--- (c) the addresses for a reward (chimeric) account
 data AccountingStyle
     = UTxOExternal
     | UTxOInternal
-    | MutableAccount
     deriving (Generic, Typeable, Show, Eq, Ord, Bounded)
 
 instance NFData AccountingStyle
@@ -287,12 +285,10 @@ instance Enum AccountingStyle where
     toEnum = \case
         0 -> UTxOExternal
         1 -> UTxOInternal
-        2 -> MutableAccount
         _ -> error "AccountingStyle.toEnum: bad argument"
     fromEnum = \case
         UTxOExternal -> 0
         UTxOInternal -> 1
-        MutableAccount -> 2
 
 -- | A derivation index, with phantom-types to disambiguate derivation type.
 --


### PR DESCRIPTION
This makes the API a bit clearer about what key is what. In the end, users needs not to know that the staking key is located at the same path in the derivation tree. 