### PR TITLE
re-export specialized function from Cardano.Address for better documentation

### DIFF
--- a/src/Cardano/Address/Style/Icarus.hs
+++ b/src/Cardano/Address/Style/Icarus.hs
@@ -19,11 +19,21 @@ module Cardano.Address.Style.Icarus
 
       -- * Icarus
       Icarus
-
-      -- * Accessors
     , getKey
 
-      -- * Discrimination
+      -- * Key Derivation
+      -- $keyDerivation
+    , genMasterKeyFromXPrv
+    , genMasterKeyFromMnemonic
+    , deriveAccountPrivateKey
+    , deriveAddressPrivateKey
+    , deriveAddressPublicKey
+
+      -- * Addresses
+      -- $addresses
+    , paymentAddress
+
+      -- * Network Discrimination
     , icarusMainnet
     , icarusStaging
     , icarusTestnet
@@ -39,10 +49,10 @@ module Cardano.Address.Style.Icarus
 import Prelude
 
 import Cardano.Address
-    ( AddressDiscrimination (..)
+    ( Address
+    , AddressDiscrimination (..)
     , NetworkDiscriminant (..)
     , NetworkTag (..)
-    , PaymentAddress (..)
     , unsafeMkAddress
     )
 import Cardano.Address.Derivation
@@ -50,11 +60,9 @@ import Cardano.Address.Derivation
     , Depth (..)
     , DerivationScheme (..)
     , DerivationType (..)
-    , GenMasterKey (..)
-    , HardDerivation (..)
     , Index
-    , SoftDerivation (..)
     , XPrv
+    , XPub
     , deriveXPrv
     , deriveXPub
     , generateNew
@@ -89,6 +97,9 @@ import Data.Word
 import GHC.Generics
     ( Generic )
 
+import qualified Cardano.Address as Internal
+import qualified Cardano.Address.Derivation as Internal
+
 import qualified Cardano.Codec.Cbor as CBOR
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
 import qualified Data.ByteArray as BA
@@ -100,48 +111,15 @@ import qualified Data.Text.Encoding as T
 --
 -- This module provides an implementation of:
 --
--- - 'GenMasterKey': for generating Icarus master keys from mnemonic sentences
--- - 'HardDerivation': for hierarchical hard derivation of parent to child keys
--- - 'SoftDerivation': for hierarchical soft derivation of parent to child keys
--- - 'PaymentAddress': for constructing addresses from a public key
+-- - 'Cardano.Address.Derivation.GenMasterKey': for generating Icarus master keys from mnemonic sentences
+-- - 'Cardano.Address.Derivation.HardDerivation': for hierarchical hard derivation of parent to child keys
+-- - 'Cardano.Address.Derivation.SoftDerivation': for hierarchical soft derivation of parent to child keys
+-- - 'Cardano.Address.PaymentAddress': for constructing addresses from a public key
 --
 -- We call 'Icarus' addresses the new format of Cardano addresses which came
--- after 'Byron'. This is the format used by /Yoroi/ and now also used by
--- /Daedalus/.
---
--- == Examples
---
--- === Generating a root key from 'SomeMnemonic'
--- > :set -XOverloadedStrings
--- > :set -XTypeApplications
--- > :set -XDataKinds
--- > import Cardano.Mnemonic ( mkSomeMnemonic )
--- > import Cardano.Address.Derivation ( GenMasterKey(..) )
--- >
--- > let (Right mw) = mkSomeMnemonic @'[15] ["network","empty","cause","mean","expire","private","finger","accident","session","problem","absurd","banner","stage","void","what"]
--- > let sndFactor = mempty -- Or alternatively, a second factor passphrase
--- > let rootK = genMasterKeyFromMnemonic mw sndFactor :: Icarus 'RootK XPrv
---
--- === Generating an 'Address' from a root key
---
--- Let's consider the following 3rd, 4th and 5th derivation paths @0'/0/14@
---
---
--- > import Cardano.Address ( PaymentAddress(..), base58, mainnetDiscriminant )
--- > import Cardano.Address.Derivation ( AccountingStyle(..), GenMasterKey(..), toXPub )
--- >
--- > let accIx = toEnum 0x80000000
--- > let acctK = deriveAccountPrivateKey rootK accIx
--- >
--- > let addIx = toEnum 0x00000014
--- > let addrK = deriveAddressPrivateKey acctK UTxOExternal addIx
--- >
--- > base58 $ paymentAddress mainnetDiscriminant (toXPub <$> addrK)
--- > "Ae2tdPwUPEZ8XpsjgQPH2cJdtohkYrxJ3i5y6mVsrkZZkdpdn6mnr4Rt6wG"
+-- after 'Cardano.Address.Style.Byron.Byron'. This is the format initially used in /Yoroi/
+-- and now also used by /Daedalus/.
 
-{-------------------------------------------------------------------------------
-                                   Key Types
--------------------------------------------------------------------------------}
 -- | A cryptographic key for sequential-scheme address derivation, with
 -- phantom-types to disambiguate key types.
 --
@@ -164,8 +142,196 @@ deriving instance (Functor (Icarus depth))
 instance (NFData key) => NFData (Icarus depth key)
 
 --
+-- Key Derivation
+--
+-- $keyDerivation
+--
+-- === Generating a root key from 'SomeMnemonic'
+-- > :set -XOverloadedStrings
+-- > :set -XTypeApplications
+-- > :set -XDataKinds
+-- > import Cardano.Mnemonic ( mkSomeMnemonic )
+-- >
+-- > let (Right mw) = mkSomeMnemonic @'[15] ["network","empty","cause","mean","expire","private","finger","accident","session","problem","absurd","banner","stage","void","what"]
+-- > let sndFactor = mempty -- Or alternatively, a second factor mnemonic transformed to bytes via someMnemonicToBytes
+-- > let rootK = genMasterKeyFromMnemonic mw sndFactor :: Icarus 'RootK XPrv
+--
+-- === Deriving child keys
+--
+-- Let's consider the following 3rd, 4th and 5th derivation paths @0'\/0\/14@
+--
+-- > import Cardano.Address.Derivation ( AccountingStyle(..) )
+-- >
+-- > let accIx = toEnum 0x80000000
+-- > let acctK = deriveAccountPrivateKey rootK accIx
+-- >
+-- > let addIx = toEnum 0x00000014
+-- > let addrK = deriveAddressPrivateKey acctK UTxOExternal addIx
+
+instance Internal.GenMasterKey Icarus where
+    type SecondFactor Icarus = ScrubbedBytes
+
+    genMasterKeyFromXPrv = liftXPrv
+    genMasterKeyFromMnemonic (SomeMnemonic mw) sndFactor =
+        let
+            seed  = entropyToBytes $ mnemonicToEntropy mw
+            seedValidated = assert
+                (BA.length seed >= minSeedLengthBytes && BA.length seed <= 255)
+                seed
+        in Icarus $ generateNew seedValidated sndFactor
+
+instance Internal.HardDerivation Icarus where
+    type AccountIndexDerivationType Icarus = 'Hardened
+    type AddressIndexDerivationType Icarus = 'Soft
+    type WithAccountStyle Icarus = AccountingStyle
+
+    deriveAccountPrivateKey (Icarus rootXPrv) accIx =
+        let
+            purposeIx =
+                toEnum @(Index 'Hardened _) $ fromEnum purposeIndex
+            coinTypeIx =
+                toEnum @(Index 'Hardened _) $ fromEnum coinTypeIndex
+            purposeXPrv = -- lvl1 derivation; hardened derivation of purpose'
+                deriveXPrv DerivationScheme2 rootXPrv purposeIx
+            coinTypeXPrv = -- lvl2 derivation; hardened derivation of coin_type'
+                deriveXPrv DerivationScheme2 purposeXPrv coinTypeIx
+            acctXPrv = -- lvl3 derivation; hardened derivation of account' index
+                deriveXPrv DerivationScheme2 coinTypeXPrv accIx
+        in
+            Icarus acctXPrv
+
+    deriveAddressPrivateKey (Icarus accXPrv) accountingStyle addrIx =
+        let
+            changeCode =
+                toEnum @(Index 'Soft _) $ fromEnum accountingStyle
+            changeXPrv = -- lvl4 derivation; soft derivation of change chain
+                deriveXPrv DerivationScheme2 accXPrv changeCode
+            addrXPrv = -- lvl5 derivation; soft derivation of address index
+                deriveXPrv DerivationScheme2 changeXPrv addrIx
+        in
+            Icarus addrXPrv
+
+instance Internal.SoftDerivation Icarus where
+    deriveAddressPublicKey (Icarus accXPub) accountingStyle addrIx =
+        fromMaybe errWrongIndex $ do
+            let changeCode = toEnum @(Index 'Soft _) $ fromEnum accountingStyle
+            changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
+                deriveXPub DerivationScheme2 accXPub changeCode
+            addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain
+                deriveXPub DerivationScheme2 changeXPub addrIx
+            return $ Icarus addrXPub
+      where
+        errWrongIndex = error $
+            "deriveAddressPublicKey failed: was given an hardened (or too big) \
+            \index for soft path derivation ( " ++ show addrIx ++ "). This is \
+            \either a programmer error, or, we may have reached the maximum \
+            \number of addresses for a given wallet."
+
+-- | Generate a root key from a corresponding mnemonic.
+--
+-- @since 1.0.0
+genMasterKeyFromMnemonic
+    :: SomeMnemonic
+        -- ^ Some valid mnemonic sentence.
+    -> ScrubbedBytes
+        -- ^ An optional second-factor passphrase (or 'mempty')
+    -> Icarus 'RootK XPrv
+genMasterKeyFromMnemonic =
+    Internal.genMasterKeyFromMnemonic
+
+-- | Generate a root key from a corresponding root 'XPrv'
+--
+-- @since 1.0.0
+genMasterKeyFromXPrv
+    :: XPrv
+    -> Icarus 'RootK XPrv
+genMasterKeyFromXPrv =
+    Internal.genMasterKeyFromXPrv
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.
+--
+-- | Derives an account private key from the given root private key.
+--
+-- @since 1.0.0
+deriveAccountPrivateKey
+    :: Icarus 'RootK XPrv
+    -> Index 'Hardened 'AccountK
+    -> Icarus 'AccountK XPrv
+deriveAccountPrivateKey =
+    Internal.deriveAccountPrivateKey
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.
+--
+-- | Derives an address private key from the given account private key.
+--
+-- @since 1.0.0
+deriveAddressPrivateKey
+    :: Icarus 'AccountK XPrv
+    -> AccountingStyle
+    -> Index 'Soft 'AddressK
+    -> Icarus 'AddressK XPrv
+deriveAddressPrivateKey =
+    Internal.deriveAddressPrivateKey
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock
+--
+-- | Derives an address public key from the given account public key.
+--
+-- @since 1.0.0
+deriveAddressPublicKey
+    :: Icarus 'AccountK XPub
+    -> AccountingStyle
+    -> Index 'Soft 'AddressK
+    -> Icarus 'AddressK XPub
+deriveAddressPublicKey =
+    Internal.deriveAddressPublicKey
+
+--
+-- Addresses
+--
+-- $addresses
+-- === Generating a 'PaymentAddress'
+--
+-- > import Cardano.Address ( bech32 )
+-- > import Cardano.Address.Derivation ( AccountingStyle(..), toXPub(..) )
+-- >
+-- > bech32 $ paymentAddress icarusMainnet (toXPub <$> addrK)
+-- > "addr1vxpfffuj3zkp5g7ct6h4va89caxx9ayq2gvkyfvww48sdncxsce5t"
+
+instance Internal.PaymentAddress Icarus where
+    paymentAddress discrimination k = unsafeMkAddress
+        $ CBOR.toStrictByteString
+        $ CBOR.encodeAddress (getKey k) attrs
+      where
+        NetworkTag magic = networkTag @Icarus discrimination
+        attrs = case addressDiscrimination @Icarus discrimination of
+            RequiresNetworkTag ->
+                [ CBOR.encodeProtocolMagicAttr magic
+                ]
+            RequiresNoTag ->
+                []
+
+-- Re-export from 'Cardano.Address' to have it documented specialized in Haddock.
+--
+-- | Convert a public key to a payment 'Address' valid for the given
+-- network discrimination.
+--
+-- @since 1.0.0
+paymentAddress
+    :: NetworkDiscriminant Icarus
+    -> Icarus 'AddressK XPub
+    -> Address
+paymentAddress =
+    Internal.paymentAddress
+
+--
 -- Network Discrimination
 --
+
+instance HasNetworkDiscriminant Icarus where
+    type NetworkDiscriminant Icarus = (AddressDiscrimination, NetworkTag)
+    addressDiscrimination = fst
+    networkTag = snd
 
 -- | 'NetworkDiscriminant' for Cardano MainNet & 'Icarus'
 --
@@ -200,90 +366,11 @@ icarusTestnet = byronTestnet
 liftXPrv :: XPrv -> Icarus depth XPrv
 liftXPrv = Icarus
 
-instance GenMasterKey Icarus where
-    type SecondFactor Icarus = ScrubbedBytes
+--
+-- Internal
+--
 
-    genMasterKeyFromXPrv = liftXPrv
-    genMasterKeyFromMnemonic (SomeMnemonic mw) sndFactor =
-        let
-            seed  = entropyToBytes $ mnemonicToEntropy mw
-            seedValidated = assert
-                (BA.length seed >= minSeedLengthBytes && BA.length seed <= 255)
-                seed
-        in Icarus $ generateNew seedValidated sndFactor
-
-instance HardDerivation Icarus where
-    type AccountIndexDerivationType Icarus = 'Hardened
-    type AddressIndexDerivationType Icarus = 'Soft
-    type WithAccountStyle Icarus = AccountingStyle
-
-    deriveAccountPrivateKey (Icarus rootXPrv) accIx =
-        let
-            purposeIx =
-                toEnum @(Index 'Hardened _) $ fromEnum purposeIndex
-            coinTypeIx =
-                toEnum @(Index 'Hardened _) $ fromEnum coinTypeIndex
-            purposeXPrv = -- lvl1 derivation; hardened derivation of purpose'
-                deriveXPrv DerivationScheme2 rootXPrv purposeIx
-            coinTypeXPrv = -- lvl2 derivation; hardened derivation of coin_type'
-                deriveXPrv DerivationScheme2 purposeXPrv coinTypeIx
-            acctXPrv = -- lvl3 derivation; hardened derivation of account' index
-                deriveXPrv DerivationScheme2 coinTypeXPrv accIx
-        in
-            Icarus acctXPrv
-
-    deriveAddressPrivateKey (Icarus accXPrv) accountingStyle addrIx =
-        let
-            changeCode =
-                toEnum @(Index 'Soft _) $ fromEnum accountingStyle
-            changeXPrv = -- lvl4 derivation; soft derivation of change chain
-                deriveXPrv DerivationScheme2 accXPrv changeCode
-            addrXPrv = -- lvl5 derivation; soft derivation of address index
-                deriveXPrv DerivationScheme2 changeXPrv addrIx
-        in
-            Icarus addrXPrv
-
-instance SoftDerivation Icarus where
-    deriveAddressPublicKey (Icarus accXPub) accountingStyle addrIx =
-        fromMaybe errWrongIndex $ do
-            let changeCode = toEnum @(Index 'Soft _) $ fromEnum accountingStyle
-            changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
-                deriveXPub DerivationScheme2 accXPub changeCode
-            addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain
-                deriveXPub DerivationScheme2 changeXPub addrIx
-            return $ Icarus addrXPub
-      where
-        errWrongIndex = error $
-            "deriveAddressPublicKey failed: was given an hardened (or too big) \
-            \index for soft path derivation ( " ++ show addrIx ++ "). This is \
-            \either a programmer error, or, we may have reached the maximum \
-            \number of addresses for a given wallet."
-
-instance HasNetworkDiscriminant Icarus where
-    type NetworkDiscriminant Icarus = (AddressDiscrimination, NetworkTag)
-
-    addressDiscrimination = fst
-    networkTag = snd
-
-
-instance PaymentAddress Icarus where
-    paymentAddress discrimination k = unsafeMkAddress
-        $ CBOR.toStrictByteString
-        $ CBOR.encodeAddress (getKey k) attrs
-      where
-        NetworkTag magic = networkTag @Icarus discrimination
-        attrs = case addressDiscrimination @Icarus discrimination of
-            RequiresNetworkTag ->
-                [ CBOR.encodeProtocolMagicAttr magic
-                ]
-            RequiresNoTag ->
-                []
-
-{-------------------------------------------------------------------------------
-                                 Key generation
--------------------------------------------------------------------------------}
-
--- | Purpose is a constant set to 44' (or 0x8000002C) following the original
+-- Purpose is a constant set to 44' (or 0x8000002C) following the original
 -- BIP-44 specification.
 --
 -- It indicates that the subtree of this node is used according to this
@@ -293,7 +380,7 @@ instance PaymentAddress Icarus where
 purposeIndex :: Word32
 purposeIndex = 0x8000002C
 
--- | One master node (seed) can be used for unlimited number of independent
+-- One master node (seed) can be used for unlimited number of independent
 -- cryptocoins such as Bitcoin, Litecoin or Namecoin. However, sharing the
 -- same space for various cryptocoins has some disadvantages.
 --

--- a/src/Cardano/Address/Style/Icarus.hs
+++ b/src/Cardano/Address/Style/Icarus.hs
@@ -99,7 +99,6 @@ import GHC.Generics
 
 import qualified Cardano.Address as Internal
 import qualified Cardano.Address.Derivation as Internal
-
 import qualified Cardano.Codec.Cbor as CBOR
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
 import qualified Data.ByteArray as BA

--- a/src/Cardano/Address/Style/Jormungandr.hs
+++ b/src/Cardano/Address/Style/Jormungandr.hs
@@ -71,7 +71,7 @@ import Cardano.Address.Derivation
     , deriveXPrv
     , deriveXPub
     , generateNew
-    , getPublicKey
+    , xpubPublicKey
     )
 import Cardano.Mnemonic
     ( SomeMnemonic, someMnemonicToBytes )
@@ -332,7 +332,7 @@ instance Internal.PaymentAddress Jormungandr where
     paymentAddress discrimination k = unsafeMkAddress $
         invariantSize expectedLength $ BL.toStrict $ runPut $ do
             putWord8 (invariantNetworkTag 255 firstByte)
-            putByteString (getPublicKey $ getKey k)
+            putByteString (xpubPublicKey $ getKey k)
       where
           firstByte = networkTag @Jormungandr discrimination
           expectedLength = 1 + publicKeySize
@@ -341,8 +341,8 @@ instance Internal.DelegationAddress Jormungandr where
     delegationAddress discrimination paymentKey stakingKey = unsafeMkAddress $
         invariantSize expectedLength $ BL.toStrict $ runPut $ do
             putWord8 (invariantNetworkTag 255 $ NetworkTag $ firstByte + 1)
-            putByteString . getPublicKey . getKey $ paymentKey
-            putByteString . getPublicKey . getKey $ stakingKey
+            putByteString . xpubPublicKey . getKey $ paymentKey
+            putByteString . xpubPublicKey . getKey $ stakingKey
       where
           (NetworkTag firstByte) = networkTag @Jormungandr discrimination
           expectedLength = 1 + 2*publicKeySize

--- a/src/Cardano/Address/Style/Jormungandr.hs
+++ b/src/Cardano/Address/Style/Jormungandr.hs
@@ -20,11 +20,23 @@ module Cardano.Address.Style.Jormungandr
 
       -- * Jormungandr
       Jormungandr
-
-      -- * Accessors
     , getKey
 
-      -- * Discrimination
+      -- * Key Derivation
+      -- $keyDerivation
+    , genMasterKeyFromXPrv
+    , genMasterKeyFromMnemonic
+    , deriveAccountPrivateKey
+    , deriveAddressPrivateKey
+    , deriveAddressPublicKey
+    , deriveStakingPrivateKey
+
+      -- * Addresses
+      -- $addresses
+    , paymentAddress
+    , delegationAddress
+
+      -- * Network Discrimination
     , incentivizedTestnet
 
       -- * Unsafe
@@ -40,11 +52,10 @@ module Cardano.Address.Style.Jormungandr
 import Prelude
 
 import Cardano.Address
-    ( AddressDiscrimination (..)
-    , DelegationAddress (..)
+    ( Address
+    , AddressDiscrimination (..)
     , HasNetworkDiscriminant (..)
     , NetworkTag (..)
-    , PaymentAddress (..)
     , invariantNetworkTag
     , invariantSize
     , unsafeMkAddress
@@ -54,19 +65,16 @@ import Cardano.Address.Derivation
     , Depth (..)
     , DerivationScheme (..)
     , DerivationType (..)
-    , GenMasterKey (..)
-    , HardDerivation (..)
     , Index
-    , SoftDerivation (..)
-    , StakingDerivation (..)
     , XPrv
+    , XPub
     , deriveXPrv
     , deriveXPub
     , generateNew
     , getPublicKey
     )
 import Cardano.Mnemonic
-    ( someMnemonicToBytes )
+    ( SomeMnemonic, someMnemonicToBytes )
 import Control.DeepSeq
     ( NFData )
 import Control.Exception.Base
@@ -82,6 +90,8 @@ import Data.Word
 import GHC.Generics
     ( Generic )
 
+import qualified Cardano.Address as Internal
+import qualified Cardano.Address.Derivation as Internal
 import qualified Crypto.PubKey.Ed25519 as Ed25519
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Lazy as BL
@@ -90,49 +100,20 @@ import qualified Data.ByteString.Lazy as BL
 --
 -- This module provides an implementation of:
 --
--- - 'GenMasterKey': for generating Jormungandr master keys from mnemonic sentences
--- - 'HardDerivation': for hierarchical hard derivation of parent to child keys
--- - 'SoftDerivation': for hierarchical soft derivation of parent to child keys
--- - 'PaymentAddress': for constructing payment addresses from a address public key
--- - 'DelegationAddress': for constructing payment addresses from a address and stake public keys
+-- - 'Cardano.Address.Derivation.GenMasterKey': for generating Jormungandr master keys from mnemonic sentences
+-- - 'Cardano.Address.Derivation.HardDerivation': for hierarchical hard derivation of parent to child keys
+-- - 'Cardano.Address.Derivation.SoftDerivation': for hierarchical soft derivation of parent to child keys
+-- - 'Cardano.Address.PaymentAddress': for constructing payment addresses from a address public key
+-- - 'Cardano.Address.DelegationAddress': for constructing payment addresses from a address and stake public keys
 --
--- == Examples
+-- == Disclaimer
 --
--- === Generating a root key from 'SomeMnemonic'
--- > :set -XOverloadedStrings
--- > :set -XTypeApplications
--- > :set -XDataKinds
--- > import Cardano.Mnemonic ( mkSomeMnemonic )
--- > import Cardano.Address.Derivation ( GenMasterKey(..) )
--- >
--- > let (Right mw) = mkSomeMnemonic @'[15] ["network","empty","cause","mean","expire","private","finger","accident","session","problem","absurd","banner","stage","void","what"]
--- > let sndFactor = mempty -- Or alternatively, a second factor mnemonic transformed to bytes via someMnemonicToBytes
--- > let rootK = genMasterKeyFromMnemonic mw sndFactor :: Jormungandr 'RootK XPrv
+-- Beware that this format of address have been specially crafted for the
+-- incentivized testnet (ITN). This will soon be __deprecated__ in favor of
+-- 'Cardano.Address.Style.Shelley.Shelley'.
 --
--- === Generating an 'Address' from a root key
---
--- Let's consider the following 3rd, 4th and 5th derivation paths @0'/0/14@
---
---
--- > import Cardano.Address ( PaymentAddress(..), DelegationAddress(..), bech32 )
--- > import Cardano.Address.Derivation ( AccountingStyle(..), StakingDerivation (..), GenMasterKey(..), toXPub )
--- >
--- > let accIx = toEnum 0x80000000
--- > let acctK = deriveAccountPrivateKey rootK accIx
--- >
--- > let addIx = toEnum 0x00000014
--- > let addrK = deriveAddressPrivateKey acctK UTxOExternal addIx
--- >
--- > bech32 $ paymentAddress jormungandrTestnet (toXPub <$> addrK)
--- > "addr1s0lgjsr0kjsprvkxmetgcjaxsq833rxg3g8rv528wa0l5c8wcnplq3x0w2h"
--- >
--- > let stakeK = deriveStakingPrivateKey acctK
--- > bech32 $ delegationAddress jormungandrTestnet (toXPub <$> addrK) (toXPub <$> stakeK)
--- > "addr1snlgjsr0kjsprvkxmetgcjaxsq833rxg3g8rv528wa0l5c8wcnplq9t56crgcdw8wmat0tqwj3zqeqekgs0v9hjuy85lr6pgfmy3hxh0nedreq"
+-- __New integrations should not use this address style__.
 
-{-------------------------------------------------------------------------------
-                                   Key Types
--------------------------------------------------------------------------------}
 -- | A cryptographic key for sequential-scheme address derivation, with
 -- phantom-types to disambiguate key types.
 --
@@ -154,18 +135,36 @@ newtype Jormungandr (depth :: Depth) key = Jormungandr
 deriving instance (Functor (Jormungandr depth))
 instance (NFData key) => NFData (Jormungandr depth key)
 
--- | Unsafe backdoor for constructing an 'Jormungandr' key from a raw 'XPrv'. this is
--- unsafe because it lets the caller choose the actually derivation 'depth'.
 --
--- This can be useful however when serializing / deserializing such a type, or to
--- speed up test code (and avoid having to do needless derivations from a master
--- key down to an address key for instance).
+-- Key Derivation
 --
--- @since 2.0.0
-liftXPrv :: XPrv -> Jormungandr depth XPrv
-liftXPrv = Jormungandr
+-- $keyDerivation
+--
+-- === Generating a root key from 'SomeMnemonic'
+-- > :set -XOverloadedStrings
+-- > :set -XTypeApplications
+-- > :set -XDataKinds
+-- > import Cardano.Mnemonic ( mkSomeMnemonic )
+-- >
+-- > let (Right mw) = mkSomeMnemonic @'[15] ["network","empty","cause","mean","expire","private","finger","accident","session","problem","absurd","banner","stage","void","what"]
+-- > let sndFactor = mempty -- Or alternatively, a second factor mnemonic transformed to bytes via someMnemonicToBytes
+-- > let rootK = genMasterKeyFromMnemonic mw sndFactor :: Jormungandr 'RootK XPrv
+--
+-- === Deriving child keys
+--
+-- Let's consider the following 3rd, 4th and 5th derivation paths @0'\/0\/14@
+--
+-- > import Cardano.Address.Derivation ( AccountingStyle(..) )
+-- >
+-- > let accIx = toEnum 0x80000000
+-- > let acctK = deriveAccountPrivateKey rootK accIx
+-- >
+-- > let addIx = toEnum 0x00000014
+-- > let addrK = deriveAddressPrivateKey acctK UTxOExternal addIx
+--
+-- > let stakeK = deriveStakingPrivateKey acctK
 
-instance GenMasterKey Jormungandr where
+instance Internal.GenMasterKey Jormungandr where
     type SecondFactor Jormungandr = ScrubbedBytes
 
     genMasterKeyFromXPrv = liftXPrv
@@ -177,7 +176,7 @@ instance GenMasterKey Jormungandr where
                 (BA.length seed >= minSeedLengthBytes && BA.length seed <= 255)
                 seed
 
-instance HardDerivation Jormungandr where
+instance Internal.HardDerivation Jormungandr where
     type AccountIndexDerivationType Jormungandr = 'Hardened
     type AddressIndexDerivationType Jormungandr = 'Soft
     type WithAccountStyle Jormungandr = AccountingStyle
@@ -208,7 +207,7 @@ instance HardDerivation Jormungandr where
         in
             Jormungandr addrXPrv
 
-instance SoftDerivation Jormungandr where
+instance Internal.SoftDerivation Jormungandr where
     deriveAddressPublicKey (Jormungandr accXPub) accountingStyle addrIx =
         fromMaybe errWrongIndex $ do
             let changeCode = toEnum @(Index 'Soft _) $ fromEnum accountingStyle
@@ -224,7 +223,7 @@ instance SoftDerivation Jormungandr where
             \either a programmer error, or, we may have reached the maximum \
             \number of addresses for a given wallet."
 
-instance StakingDerivation Jormungandr where
+instance Internal.StakingDerivation Jormungandr where
     deriveStakingPrivateKey (Jormungandr accXPrv) =
         let
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
@@ -234,18 +233,102 @@ instance StakingDerivation Jormungandr where
         in
             Jormungandr stakeXPrv
 
--- | 'NetworkDiscriminant' for Cardano Incentivized Testnet testnet & Jormungandr
+-- | Generate a root key from a corresponding mnemonic.
 --
 -- @since 2.0.0
-incentivizedTestnet :: NetworkDiscriminant Jormungandr
-incentivizedTestnet = NetworkTag 0x83
+genMasterKeyFromMnemonic
+    :: SomeMnemonic
+        -- ^ Some valid mnemonic sentence.
+    -> ScrubbedBytes
+        -- ^ An optional second-factor passphrase (or 'mempty')
+    -> Jormungandr 'RootK XPrv
+genMasterKeyFromMnemonic =
+    Internal.genMasterKeyFromMnemonic
 
-instance HasNetworkDiscriminant Jormungandr where
-    type NetworkDiscriminant Jormungandr = NetworkTag
-    addressDiscrimination _ = RequiresNetworkTag
-    networkTag = id
+-- | Generate a root key from a corresponding root 'XPrv'
+--
+-- @since 2.0.0
+genMasterKeyFromXPrv
+    :: XPrv -> Jormungandr 'RootK XPrv
+genMasterKeyFromXPrv =
+    Internal.genMasterKeyFromXPrv
 
-instance PaymentAddress Jormungandr where
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.
+--
+-- | Derives an account private key from the given root private key.
+--
+-- @since 2.0.0
+deriveAccountPrivateKey
+    :: Jormungandr 'RootK XPrv
+    -> Index 'Hardened 'AccountK
+    -> Jormungandr 'AccountK XPrv
+deriveAccountPrivateKey =
+    Internal.deriveAccountPrivateKey
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.
+--
+-- | Derives an address private key from the given account private key.
+--
+-- @since 2.0.0
+deriveAddressPrivateKey
+    :: Jormungandr 'AccountK XPrv
+    -> AccountingStyle
+    -> Index 'Soft 'AddressK
+    -> Jormungandr 'AddressK XPrv
+deriveAddressPrivateKey =
+    Internal.deriveAddressPrivateKey
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock
+--
+-- | Derives an address public key from the given account public key.
+--
+-- @since 2.0.0
+deriveAddressPublicKey
+    :: Jormungandr 'AccountK XPub
+    -> AccountingStyle
+    -> Index 'Soft 'AddressK
+    -> Jormungandr 'AddressK XPub
+deriveAddressPublicKey =
+    Internal.deriveAddressPublicKey
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock
+--
+-- | Derive a staking key for a corresponding 'AccountK'. Note that wallet
+-- software are by convention only using one staking key per account, and always
+-- the first account (with index 0').
+--
+-- Deriving staking keys for something else than the initial account is not
+-- recommended and can lead to incompatibility with existing wallet softwares
+-- (Daedalus, Yoroi, Adalite...).
+--
+-- @since 2.0.0
+deriveStakingPrivateKey
+    :: Jormungandr 'AccountK XPrv
+    -> Jormungandr 'StakingK XPrv
+deriveStakingPrivateKey =
+    Internal.deriveStakingPrivateKey
+
+--
+-- Addresses
+--
+-- $addresses
+-- === Generating a 'PaymentAddress'
+--
+-- > import Cardano.Address ( bech32 )
+-- > import Cardano.Address.Derivation ( AccountingStyle(..), toXPub(..) )
+-- >
+-- > bech32 $ paymentAddress incentivizedTestnet (toXPub <$> addrK)
+-- > "addr1vxpfffuj3zkp5g7ct6h4va89caxx9ayq2gvkyfvww48sdncxsce5t"
+--
+-- === Generating a 'DelegationAddress'
+--
+-- > import Cardano.Address ( DelegationAddress (..) )
+-- > import Cardano.Address.Derivation ( StakingDerivation (..) )
+-- >
+-- > bech32 $ delegationAddress incentivizedTestnet (toXPub <$> addrK) (toXPub <$> stakeK)
+-- > "addr1qxpfffuj3zkp5g7ct6h4va89caxx9ayq2gvkyfvww48sdn7nudck0fzve4346yytz3wpwv9yhlxt7jwuc7ytwx2vfkyqmkc5xa"
+
+instance Internal.PaymentAddress Jormungandr where
     paymentAddress discrimination k = unsafeMkAddress $
         invariantSize expectedLength $ BL.toStrict $ runPut $ do
             putWord8 (invariantNetworkTag 255 firstByte)
@@ -254,7 +337,7 @@ instance PaymentAddress Jormungandr where
           firstByte = networkTag @Jormungandr discrimination
           expectedLength = 1 + publicKeySize
 
-instance DelegationAddress Jormungandr where
+instance Internal.DelegationAddress Jormungandr where
     delegationAddress discrimination paymentKey stakingKey = unsafeMkAddress $
         invariantSize expectedLength $ BL.toStrict $ runPut $ do
             putWord8 (invariantNetworkTag 255 $ NetworkTag $ firstByte + 1)
@@ -264,9 +347,68 @@ instance DelegationAddress Jormungandr where
           (NetworkTag firstByte) = networkTag @Jormungandr discrimination
           expectedLength = 1 + 2*publicKeySize
 
-{-------------------------------------------------------------------------------
-                                Constants
--------------------------------------------------------------------------------}
+-- Re-export from 'Cardano.Address' to have it documented specialized in Haddock.
+--
+-- | Convert a public key to a payment 'Address' valid for the given
+-- network discrimination.
+--
+-- @since 2.0.0
+paymentAddress
+    :: NetworkDiscriminant Jormungandr
+    -> Jormungandr 'AddressK XPub
+    -> Address
+paymentAddress =
+    Internal.paymentAddress
+
+-- Re-export from 'Cardano.Address' to have it documented specialized in Haddock.
+--
+-- | Convert a public key and a staking key to a delegation 'Address' valid
+-- for the given network discrimination. Funds sent to this address will be
+-- delegated according to the delegation settings attached to the delegation
+-- key.
+--
+-- @since 2.0.0
+delegationAddress
+    :: NetworkDiscriminant Jormungandr
+    -> Jormungandr 'AddressK XPub
+    -> Jormungandr 'StakingK XPub
+    -> Address
+delegationAddress =
+    Internal.delegationAddress
+
+--
+-- Network Discrimination
+--
+
+instance HasNetworkDiscriminant Jormungandr where
+    type NetworkDiscriminant Jormungandr = NetworkTag
+    addressDiscrimination _ = RequiresNetworkTag
+    networkTag = id
+
+-- | 'NetworkDiscriminant' for Cardano Incentivized Testnet testnet & Jormungandr
+--
+-- @since 2.0.0
+incentivizedTestnet :: NetworkDiscriminant Jormungandr
+incentivizedTestnet = NetworkTag 0x83
+
+--
+-- Unsafe
+--
+
+-- | Unsafe backdoor for constructing an 'Jormungandr' key from a raw 'XPrv'. this is
+-- unsafe because it lets the caller choose the actually derivation 'depth'.
+--
+-- This can be useful however when serializing / deserializing such a type, or to
+-- speed up test code (and avoid having to do needless derivations from a master
+-- key down to an address key for instance).
+--
+-- @since 2.0.0
+liftXPrv :: XPrv -> Jormungandr depth XPrv
+liftXPrv = Jormungandr
+
+--
+-- Internal
+--
 
 -- Size, in bytes, of a public key (without chain code)
 publicKeySize :: Int

--- a/src/Cardano/Address/Style/Shelley.hs
+++ b/src/Cardano/Address/Style/Shelley.hs
@@ -307,35 +307,6 @@ deriveStakingPrivateKey =
     Internal.deriveStakingPrivateKey
 
 --
--- Network Discriminant
---
-
-instance HasNetworkDiscriminant Shelley where
-    type NetworkDiscriminant Shelley = NetworkTag
-    addressDiscrimination _ = RequiresNetworkTag
-    networkTag = id
-
--- | Error reported from trying to create a network discriminant from number
---
--- @since 2.0.0
-newtype MkNetworkDiscriminantError
-    = ErrWrongNetworkTag Word8
-      -- ^ Wrong network tag.
-    deriving (Eq, Show)
-
--- | Construct 'NetworkDiscriminant' for Cardano 'Shelley' from a number.
--- If the number is invalid, ie., not between 0 and 15, then
--- 'MkNetworkDiscriminantError' is thrown.
---
--- @since 2.0.0
-mkNetworkDiscriminant
-    :: Word8
-    -> Either MkNetworkDiscriminantError (NetworkDiscriminant Shelley)
-mkNetworkDiscriminant nTag
-    | nTag < 16 =  Right $ NetworkTag $ fromIntegral nTag
-    | otherwise = Left $ ErrWrongNetworkTag nTag
-
---
 -- Addresses
 --
 -- $addresses
@@ -421,6 +392,35 @@ delegationAddress
     -> Address
 delegationAddress =
     Internal.delegationAddress
+
+--
+-- Network Discriminant
+--
+
+instance HasNetworkDiscriminant Shelley where
+    type NetworkDiscriminant Shelley = NetworkTag
+    addressDiscrimination _ = RequiresNetworkTag
+    networkTag = id
+
+-- | Error reported from trying to create a network discriminant from number
+--
+-- @since 2.0.0
+newtype MkNetworkDiscriminantError
+    = ErrWrongNetworkTag Word8
+      -- ^ Wrong network tag.
+    deriving (Eq, Show)
+
+-- | Construct 'NetworkDiscriminant' for Cardano 'Shelley' from a number.
+-- If the number is invalid, ie., not between 0 and 15, then
+-- 'MkNetworkDiscriminantError' is thrown.
+--
+-- @since 2.0.0
+mkNetworkDiscriminant
+    :: Word8
+    -> Either MkNetworkDiscriminantError (NetworkDiscriminant Shelley)
+mkNetworkDiscriminant nTag
+    | nTag < 16 =  Right $ NetworkTag $ fromIntegral nTag
+    | otherwise = Left $ ErrWrongNetworkTag nTag
 
 --
 -- Unsafe

--- a/src/Cardano/Address/Style/Shelley.hs
+++ b/src/Cardano/Address/Style/Shelley.hs
@@ -36,7 +36,7 @@ module Cardano.Address.Style.Shelley
     , paymentAddress
     , delegationAddress
 
-      -- * Discrimination
+      -- * Network Discrimination
     , MkNetworkDiscriminantError (..)
     , mkNetworkDiscriminant
 
@@ -112,9 +112,6 @@ import qualified Data.ByteString.Lazy as BL
 -- - 'Cardano.Address.PaymentAddress': for constructing payment addresses from a address public key
 -- - 'Cardano.Address.DelegationAddress': for constructing delegation addresses from address and staking public keys
 
-{-------------------------------------------------------------------------------
-                                   Key Types
--------------------------------------------------------------------------------}
 -- | A cryptographic key for sequential-scheme address derivation, with
 -- phantom-types to disambiguate key types.
 --
@@ -135,17 +132,6 @@ newtype Shelley (depth :: Depth) key = Shelley
 
 deriving instance (Functor (Shelley depth))
 instance (NFData key) => NFData (Shelley depth key)
-
--- | Unsafe backdoor for constructing an 'Shelley' key from a raw 'XPrv'. this is
--- unsafe because it lets the caller choose the actually derivation 'depth'.
---
--- This can be useful however when serializing / deserializing such a type, or to
--- speed up test code (and avoid having to do needless derivations from a master
--- key down to an address key for instance).
---
--- @since 2.0.0
-liftXPrv :: XPrv -> Shelley depth XPrv
-liftXPrv = Shelley
 
 --
 -- Key Derivation
@@ -435,6 +421,21 @@ delegationAddress
     -> Address
 delegationAddress =
     Internal.delegationAddress
+
+--
+-- Unsafe
+--
+
+-- | Unsafe backdoor for constructing an 'Shelley' key from a raw 'XPrv'. this is
+-- unsafe because it lets the caller choose the actually derivation 'depth'.
+--
+-- This can be useful however when serializing / deserializing such a type, or to
+-- speed up test code (and avoid having to do needless derivations from a master
+-- key down to an address key for instance).
+--
+-- @since 2.0.0
+liftXPrv :: XPrv -> Shelley depth XPrv
+liftXPrv = Shelley
 
 --
 -- Internal

--- a/src/Cardano/Address/Style/Shelley.hs
+++ b/src/Cardano/Address/Style/Shelley.hs
@@ -70,7 +70,7 @@ import Cardano.Address.Derivation
     , deriveXPrv
     , deriveXPub
     , generateNew
-    , getPublicKey
+    , xpubPublicKey
     )
 import Cardano.Mnemonic
     ( SomeMnemonic, someMnemonicToBytes )
@@ -444,7 +444,7 @@ liftXPrv = Shelley
 -- Hash a public key
 blake2b224 :: Shelley depth XPub -> ByteString
 blake2b224 =
-    BA.convert . hash @_ @Blake2b_224 . getPublicKey . getKey
+    BA.convert . hash @_ @Blake2b_224 . xpubPublicKey . getKey
 
 
 -- Size, in bytes, of a hash of public key (without the corresponding chain code)

--- a/src/Cardano/Address/Style/Shelley.hs
+++ b/src/Cardano/Address/Style/Shelley.hs
@@ -20,13 +20,25 @@ module Cardano.Address.Style.Shelley
 
       -- * Shelley
       Shelley
+    , getKey
+
+      -- * Key Derivation
+      -- $keyDerivation
+    , genMasterKeyFromXPrv
+    , genMasterKeyFromMnemonic
+    , deriveAccountPrivateKey
+    , deriveAddressPrivateKey
+    , deriveStakingPrivateKey
+    , deriveAddressPublicKey
+
+      -- * Addresses
+      -- $addresses
+    , paymentAddress
+    , delegationAddress
 
       -- * Discrimination
     , MkNetworkDiscriminantError (..)
     , mkNetworkDiscriminant
-
-      -- * Accessors
-    , getKey
 
       -- * Unsafe
     , liftXPrv
@@ -39,11 +51,10 @@ module Cardano.Address.Style.Shelley
 import Prelude
 
 import Cardano.Address
-    ( AddressDiscrimination (..)
-    , DelegationAddress (..)
+    ( Address
+    , AddressDiscrimination (..)
     , NetworkDiscriminant (..)
     , NetworkTag (..)
-    , PaymentAddress (..)
     , invariantNetworkTag
     , invariantSize
     , unsafeMkAddress
@@ -53,11 +64,7 @@ import Cardano.Address.Derivation
     , Depth (..)
     , DerivationScheme (..)
     , DerivationType (..)
-    , GenMasterKey (..)
-    , HardDerivation (..)
     , Index
-    , SoftDerivation (..)
-    , StakingDerivation (..)
     , XPrv
     , XPub
     , deriveXPrv
@@ -66,7 +73,7 @@ import Cardano.Address.Derivation
     , getPublicKey
     )
 import Cardano.Mnemonic
-    ( someMnemonicToBytes )
+    ( SomeMnemonic, someMnemonicToBytes )
 import Control.DeepSeq
     ( NFData )
 import Control.Exception.Base
@@ -90,6 +97,8 @@ import Data.Word
 import GHC.Generics
     ( Generic )
 
+import qualified Cardano.Address as Internal
+import qualified Cardano.Address.Derivation as Internal
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Lazy as BL
 
@@ -97,46 +106,11 @@ import qualified Data.ByteString.Lazy as BL
 --
 -- This module provides an implementation of:
 --
--- - 'GenMasterKey': for generating Shelley master keys from mnemonic sentences
--- - 'HardDerivation': for hierarchical hard derivation of parent to child keys
--- - 'SoftDerivation': for hierarchical soft derivation of parent to child keys
--- - 'PaymentAddress': for constructing payment addresses from a address public key
--- - 'DelegationAddress': for constructing delegation addresses from address and staking public keys
---
--- == Examples
---
--- === Generating a root key from 'SomeMnemonic'
--- > :set -XOverloadedStrings
--- > :set -XTypeApplications
--- > :set -XDataKinds
--- > import Cardano.Mnemonic ( mkSomeMnemonic )
--- > import Cardano.Address.Derivation ( GenMasterKey(..) )
--- >
--- > let (Right mw) = mkSomeMnemonic @'[15] ["network","empty","cause","mean","expire","private","finger","accident","session","problem","absurd","banner","stage","void","what"]
--- > let sndFactor = mempty -- Or alternatively, a second factor mnemonic transformed to bytes via someMnemonicToBytes
--- > let rootK = genMasterKeyFromMnemonic mw sndFactor :: Shelley 'RootK XPrv
---
--- === Generating an 'PaymentAddress' and 'DelegationAddress' from a root key
---
--- Let's consider the following 3rd, 4th and 5th derivation paths @0'/0/14@
---
---
--- > import Cardano.Address ( PaymentAddress(..), DelegationAddress (..), bech32)
--- > import Cardano.Address.Derivation ( AccountingStyle(..), StakingDerivation (..), GenMasterKey(..), toXPub )
--- >
--- > let accIx = toEnum 0x80000000
--- > let acctK = deriveAccountPrivateKey rootK accIx
--- >
--- > let addIx = toEnum 0x00000014
--- > let addrK = deriveAddressPrivateKey acctK UTxOExternal addIx
--- >
--- > let (Right netTag) = mkNetworkDiscriminant 1
--- > bech32 $ paymentAddress netTag (toXPub <$> addrK)
--- > "addr1vxpfffuj3zkp5g7ct6h4va89caxx9ayq2gvkyfvww48sdncxsce5t"
--- >
--- > let stakeK = deriveStakingPrivateKey acctK
--- > bech32 $ delegationAddress netTag (toXPub <$> addrK) (toXPub <$> stakeK)
--- > "addr1qxpfffuj3zkp5g7ct6h4va89caxx9ayq2gvkyfvww48sdn7nudck0fzve4346yytz3wpwv9yhlxt7jwuc7ytwx2vfkyqmkc5xa"
+-- - 'Cardano.Address.Derivation.GenMasterKey': for generating Shelley master keys from mnemonic sentences
+-- - 'Cardano.Address.Derivation.HardDerivation': for hierarchical hard derivation of parent to child keys
+-- - 'Cardano.Address.Derivation.SoftDerivation': for hierarchical soft derivation of parent to child keys
+-- - 'Cardano.Address.PaymentAddress': for constructing payment addresses from a address public key
+-- - 'Cardano.Address.DelegationAddress': for constructing delegation addresses from address and staking public keys
 
 {-------------------------------------------------------------------------------
                                    Key Types
@@ -173,7 +147,36 @@ instance (NFData key) => NFData (Shelley depth key)
 liftXPrv :: XPrv -> Shelley depth XPrv
 liftXPrv = Shelley
 
-instance GenMasterKey Shelley where
+--
+-- Key Derivation
+--
+-- $keyDerivation
+--
+-- === Generating a root key from 'SomeMnemonic'
+-- > :set -XOverloadedStrings
+-- > :set -XTypeApplications
+-- > :set -XDataKinds
+-- > import Cardano.Mnemonic ( mkSomeMnemonic )
+-- >
+-- > let (Right mw) = mkSomeMnemonic @'[15] ["network","empty","cause","mean","expire","private","finger","accident","session","problem","absurd","banner","stage","void","what"]
+-- > let sndFactor = mempty -- Or alternatively, a second factor mnemonic transformed to bytes via someMnemonicToBytes
+-- > let rootK = genMasterKeyFromMnemonic mw sndFactor :: Shelley 'RootK XPrv
+--
+-- === Deriving child keys
+--
+-- Let's consider the following 3rd, 4th and 5th derivation paths @0'\/0\/14@
+--
+-- > import Cardano.Address.Derivation ( AccountingStyle(..) )
+-- >
+-- > let accIx = toEnum 0x80000000
+-- > let acctK = deriveAccountPrivateKey rootK accIx
+-- >
+-- > let addIx = toEnum 0x00000014
+-- > let addrK = deriveAddressPrivateKey acctK UTxOExternal addIx
+--
+-- > let stakeK = deriveStakingPrivateKey acctK
+
+instance Internal.GenMasterKey Shelley where
     type SecondFactor Shelley = ScrubbedBytes
 
     genMasterKeyFromXPrv = liftXPrv
@@ -185,7 +188,7 @@ instance GenMasterKey Shelley where
                 (BA.length seed >= minSeedLengthBytes && BA.length seed <= 255)
                 seed
 
-instance HardDerivation Shelley where
+instance Internal.HardDerivation Shelley where
     type AccountIndexDerivationType Shelley = 'Hardened
     type AddressIndexDerivationType Shelley = 'Soft
     type WithAccountStyle Shelley = AccountingStyle
@@ -216,7 +219,7 @@ instance HardDerivation Shelley where
         in
             Shelley addrXPrv
 
-instance SoftDerivation Shelley where
+instance Internal.SoftDerivation Shelley where
     deriveAddressPublicKey (Shelley accXPub) accountingStyle addrIx =
         fromMaybe errWrongIndex $ do
             let changeCode = toEnum @(Index 'Soft _) $ fromEnum accountingStyle
@@ -232,7 +235,7 @@ instance SoftDerivation Shelley where
             \either a programmer error, or, we may have reached the maximum \
             \number of addresses for a given wallet."
 
-instance StakingDerivation Shelley where
+instance Internal.StakingDerivation Shelley where
     deriveStakingPrivateKey (Shelley accXPrv) =
         let
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
@@ -241,6 +244,85 @@ instance StakingDerivation Shelley where
                 deriveXPrv DerivationScheme2 changeXPrv (minBound @(Index 'Soft _))
         in
             Shelley stakeXPrv
+
+-- | Generate a root key from a corresponding mnemonic.
+--
+-- @since 2.0.0
+genMasterKeyFromMnemonic
+    :: SomeMnemonic
+        -- ^ Some valid mnemonic sentence.
+    -> ScrubbedBytes
+        -- ^ An optional second-factor passphrase (or 'mempty')
+    -> Shelley 'RootK XPrv
+genMasterKeyFromMnemonic =
+    Internal.genMasterKeyFromMnemonic
+
+-- | Generate a root key from a corresponding root 'XPrv'
+--
+-- @since 2.0.0
+genMasterKeyFromXPrv
+    :: XPrv -> Shelley 'RootK XPrv
+genMasterKeyFromXPrv =
+    Internal.genMasterKeyFromXPrv
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.
+--
+-- | Derives an account private key from the given root private key.
+--
+-- @since 2.0.0
+deriveAccountPrivateKey
+    :: Shelley 'RootK XPrv
+    -> Index 'Hardened 'AccountK
+    -> Shelley 'AccountK XPrv
+deriveAccountPrivateKey =
+    Internal.deriveAccountPrivateKey
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.
+--
+-- | Derives an address private key from the given account private key.
+--
+-- @since 2.0.0
+deriveAddressPrivateKey
+    :: Shelley 'AccountK XPrv
+    -> AccountingStyle
+    -> Index 'Soft 'AddressK
+    -> Shelley 'AddressK XPrv
+deriveAddressPrivateKey =
+    Internal.deriveAddressPrivateKey
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock
+--
+-- | Derives an address public key from the given account public key.
+--
+-- @since 2.0.0
+deriveAddressPublicKey
+    :: Shelley 'AccountK XPub
+    -> AccountingStyle
+    -> Index 'Soft 'AddressK
+    -> Shelley 'AddressK XPub
+deriveAddressPublicKey =
+    Internal.deriveAddressPublicKey
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock
+--
+-- | Derive a staking key for a corresponding 'AccountK'. Note that wallet
+-- software are by convention only using one staking key per account, and always
+-- the first account (with index 0').
+--
+-- Deriving staking keys for something else than the initial account is not
+-- recommended and can lead to incompatibility with existing wallet softwares
+-- (Daedalus, Yoroi, Adalite...).
+--
+-- @since 2.0.0
+deriveStakingPrivateKey
+    :: Shelley 'AccountK XPrv
+    -> Shelley 'StakingK XPrv
+deriveStakingPrivateKey =
+    Internal.deriveStakingPrivateKey
+
+--
+-- Network Discriminant
+--
 
 instance HasNetworkDiscriminant Shelley where
     type NetworkDiscriminant Shelley = NetworkTag
@@ -267,7 +349,29 @@ mkNetworkDiscriminant nTag
     | nTag < 16 =  Right $ NetworkTag $ fromIntegral nTag
     | otherwise = Left $ ErrWrongNetworkTag nTag
 
-instance PaymentAddress Shelley where
+--
+-- Addresses
+--
+-- $addresses
+-- === Generating a 'PaymentAddress'
+--
+-- > import Cardano.Address ( bech32 )
+-- > import Cardano.Address.Derivation ( AccountingStyle(..), toXPub(..) )
+-- >
+-- > let (Right tag) = mkNetworkDiscriminant 1
+-- > bech32 $ paymentAddress tag (toXPub <$> addrK)
+-- > "addr1vxpfffuj3zkp5g7ct6h4va89caxx9ayq2gvkyfvww48sdncxsce5t"
+--
+-- === Generating a 'DelegationAddress'
+--
+-- > import Cardano.Address ( DelegationAddress (..) )
+-- > import Cardano.Address.Derivation ( StakingDerivation (..) )
+-- >
+-- > let (Right tag) = mkNetworkDiscriminant 1
+-- > bech32 $ delegationAddress tag (toXPub <$> addrK) (toXPub <$> stakeK)
+-- > "addr1qxpfffuj3zkp5g7ct6h4va89caxx9ayq2gvkyfvww48sdn7nudck0fzve4346yytz3wpwv9yhlxt7jwuc7ytwx2vfkyqmkc5xa"
+
+instance Internal.PaymentAddress Shelley where
     paymentAddress discrimination k = unsafeMkAddress $
         invariantSize expectedLength $ BL.toStrict $ runPut $ do
             putWord8 firstByte
@@ -285,7 +389,7 @@ instance PaymentAddress Shelley where
               96 + invariantNetworkTag 16 (networkTag @Shelley discrimination)
           expectedLength = 1 + publicKeyHashSize
 
-instance DelegationAddress Shelley where
+instance Internal.DelegationAddress Shelley where
     delegationAddress discrimination paymentKey stakingKey = unsafeMkAddress $
         invariantSize expectedLength $ BL.toStrict $ runPut $ do
             putWord8 firstByte
@@ -303,19 +407,50 @@ instance DelegationAddress Shelley where
               invariantNetworkTag 16 (networkTag @Shelley discrimination)
           expectedLength = 1 + 2*publicKeyHashSize
 
+-- Re-export from 'Cardano.Address' to have it documented specialized in Haddock.
+--
+-- | Convert a public key to a payment 'Address' valid for the given
+-- network discrimination.
+--
+-- @since 2.0.0
+paymentAddress
+    :: NetworkDiscriminant Shelley
+    -> Shelley 'AddressK XPub
+    -> Address
+paymentAddress =
+    Internal.paymentAddress
+
+-- Re-export from 'Cardano.Address' to have it documented specialized in Haddock.
+--
+-- | Convert a public key and a staking key to a delegation 'Address' valid
+-- for the given network discrimination. Funds sent to this address will be
+-- delegated according to the delegation settings attached to the delegation
+-- key.
+--
+-- @since 2.0.0
+delegationAddress
+    :: NetworkDiscriminant Shelley
+    -> Shelley 'AddressK XPub
+    -> Shelley 'StakingK XPub
+    -> Address
+delegationAddress =
+    Internal.delegationAddress
+
+--
+-- Internal
+--
+
+-- Hash a public key
 blake2b224 :: Shelley depth XPub -> ByteString
 blake2b224 =
     BA.convert . hash @_ @Blake2b_224 . getPublicKey . getKey
 
-{-------------------------------------------------------------------------------
-                                 Key generation
--------------------------------------------------------------------------------}
 
--- | Size, in bytes, of a hash of public key (without the corresponding chain code)
+-- Size, in bytes, of a hash of public key (without the corresponding chain code)
 publicKeyHashSize :: Int
 publicKeyHashSize = hashDigestSize Blake2b_224
 
--- | Purpose is a constant set to 1852' (or 0x8000073c) following the BIP-44
+-- Purpose is a constant set to 1852' (or 0x8000073c) following the BIP-44
 -- extension for Cardano:
 --
 -- https://github.com/input-output-hk/implementation-decisions/blob/e2d1bed5e617f0907bc5e12cf1c3f3302a4a7c42/text/1852-hd-chimeric.md
@@ -327,7 +462,7 @@ publicKeyHashSize = hashDigestSize Blake2b_224
 purposeIndex :: Word32
 purposeIndex = 0x8000073c
 
--- | One master node (seed) can be used for unlimited number of independent
+-- One master node (seed) can be used for unlimited number of independent
 -- cryptocoins such as Bitcoin, Litecoin or Namecoin. However, sharing the
 -- same space for various cryptocoins has some disadvantages.
 --
@@ -342,6 +477,6 @@ purposeIndex = 0x8000073c
 coinTypeIndex :: Word32
 coinTypeIndex = 0x80000717
 
--- | The minimum seed length for 'genMasterKeyFromMnemonic'.
+-- The minimum seed length for 'genMasterKeyFromMnemonic'.
 minSeedLengthBytes :: Int
 minSeedLengthBytes = 16

--- a/test/Cardano/Address/DerivationSpec.hs
+++ b/test/Cardano/Address/DerivationSpec.hs
@@ -52,10 +52,10 @@ spec = describe "Checking auxiliary address derivations types" $ do
         it "Index @'Hardened _" (property prop_roundtripEnumIndexHard)
         it "Index @'Soft _" (property prop_roundtripEnumIndexSoft)
 
-    describe "bytes roundtrips" $ do
-        prop "xpubToBytes . xpubFromBytes" $
+    describe "XPub / XPrv properties" $ do
+        prop "roundtripping: xpubToBytes . xpubFromBytes" $
             prop_roundtripBytes xpubToBytes xpubFromBytes
-        prop "xprvToBytes . xprvFromBytes" $
+        prop "roundtripping: xprvToBytes . xprvFromBytes" $
             prop_roundtripBytes xprvToBytes xprvFromBytes
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Before, modules would look quite empty unless one noticed the instance declaration below the main type. Now, the documentation is a lot clearer and gives less cryptic signatures for the various interfaces. For example:

![Screenshot from 2020-05-05 15-37-19](https://user-images.githubusercontent.com/5680256/81072903-26564900-8ee7-11ea-9449-c645be8d569d.png)
![Screenshot from 2020-05-05 15-37-30](https://user-images.githubusercontent.com/5680256/81072905-26eedf80-8ee7-11ea-8765-ccad08e05542.png)

