### PR TITLE
`inspect` commands return structured JSON

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -30,7 +30,7 @@
 
 - modules:
   # Enforce some common qualified imports aliases across the codebase
-  - {name: [Data.Aeson, Data.Aeson.Types], as: Aeson}
+  - {name: [Data.Aeson, Data.Aeson.Types], as: Json}
   - {name: [Data.ByteArray], as: BA}
   - {name: [Data.ByteString.Base16], as: B16}
   - {name: [Data.ByteString.Char8], as: B8}

--- a/README.md
+++ b/README.md
@@ -109,24 +109,37 @@ xpub16y4vhpyuj2t84gh2qfe3ydng3wc37yqzxev6gce380fvvg47ye8um3dm3wn5a64gt7l0fh5j6sj
 </details>
 
 ## Docker Image
+
 ### Build
-```
+
+```console
 $ docker build -t cardano-address .
 ```
+
 ### Run
+
 Use the auto-remove flag `--rm` when running commands.
-```
+
+```console
 $ docker run --rm cardano-address recovery-phrase generate --size 15
 dismiss grit bacon glare napkin satisfy tribe proud carpet bench fantasy rich history face north
 ```
+
 Use the interactive flag `-i` when piping stdin
-```
+
+```console
 $ echo "addr1gqtnpvdhqrtpd4g424fcaq7k0ufuzyadt7djygf8qdyzevuph3wczvf2dwyx5u" | docker run --rm -i cardano-addresses address inspect
-address style:      Shelley
-stake reference:    by pointer
-spending key hash:  1730b1b700d616d51555538e83d67f13c113ad5f9b22212703482cb3
-pointer:            sl#24157 tx#177 ix#42
-network tag:        0
+{
+    "address_style": "Shelley",
+    "stake_reference": "by pointer",
+    "spending_key_hash": "1730b1b700d616d51555538e83d67f13c113ad5f9b22212703482cb3",
+    "pointer": {
+        "slot_num": 24157,
+        "output_index": 42,
+        "transaction_index": 177
+    },
+    "network_tag": 0
+}
 ```
 
 ## Contributing

--- a/cardano-addresses.cabal
+++ b/cardano-addresses.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1d81c450646d16f17cc664effa47145cb60c41e5683c91e6d92c83d61ee2df13
+-- hash: 914290d4127de4ecec3de55cab527b0bac04bd20033e880e4da520a1879ef2ab
 
 name:           cardano-addresses
 version:        1.0.0
@@ -68,7 +68,9 @@ library
   default-extensions: NoImplicitPrelude
   ghc-options: -Wall -Wcompat -fwarn-redundant-constraints
   build-depends:
-      ansi-terminal
+      aeson
+    , aeson-pretty
+    , ansi-terminal
     , base >=4.7 && <5
     , base58-bytestring
     , basement

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,8 @@ library:
   default-extensions:
   - NoImplicitPrelude
   dependencies:
+  - aeson
+  - aeson-pretty
   - ansi-terminal
   - base58-bytestring
   - basement

--- a/src/Cardano/Address/Style/Jormungandr.hs
+++ b/src/Cardano/Address/Style/Jormungandr.hs
@@ -86,6 +86,8 @@ import Control.DeepSeq
     ( NFData )
 import Control.Exception.Base
     ( assert )
+import Data.Aeson
+    ( (.=) )
 import Data.Binary.Put
     ( putByteString, putWord8, runPut )
 import Data.Bits
@@ -102,6 +104,7 @@ import GHC.Generics
 import qualified Cardano.Address as Internal
 import qualified Cardano.Address.Derivation as Internal
 import qualified Crypto.PubKey.Ed25519 as Ed25519
+import qualified Data.Aeson as Json
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
@@ -365,7 +368,7 @@ instance Internal.DelegationAddress Jormungandr where
 -- string giving details about the 'Jormungandr'.
 --
 -- @since 2.0.0
-inspectJormungandrAddress :: Address -> Maybe String
+inspectJormungandrAddress :: Address -> Maybe Json.Value
 inspectJormungandrAddress addr
     | BS.length bytes < 1 + publicKeySize = Nothing
     | otherwise =
@@ -377,37 +380,37 @@ inspectJormungandrAddress addr
         in
             case addrType of
                 0x03 | BS.length rest == size ->
-                    Just $ unlines
-                    [ "address style:    " <> "Jormungandr"
-                    , "address type:     " <> "single"
-                    , "stake reference:  " <> "none"
-                    , "spending key:     " <> base16 (BS.take size rest)
-                    , "network tag:      " <> show network
+                    Just $ Json.object
+                    [ "address_style"   .= Json.String "Jormungandr"
+                    , "address_type"    .= Json.String "single"
+                    , "stake_reference" .= Json.String "none"
+                    , "spending_key"    .= base16 (BS.take size rest)
+                    , "network_tag"     .= network
                     ]
                 0x04 | BS.length rest == 2 * size ->
-                    Just $ unlines
-                    [ "address style:    " <> "Jormungandr"
-                    , "address type:     " <> "group"
-                    , "stake reference:  " <> "by value"
-                    , "spending key:     " <> base16 (BS.take size rest)
-                    , "stake key:        " <> base16 (BS.drop size rest)
-                    , "network tag:      " <> show network
+                    Just $ Json.object
+                    [ "address_style"   .= Json.String "Jormungandr"
+                    , "address_type"    .= Json.String "group"
+                    , "stake_reference" .= Json.String "by value"
+                    , "spending_key"    .= base16 (BS.take size rest)
+                    , "stake_key"       .= base16 (BS.drop size rest)
+                    , "network_tag"     .= network
                     ]
                 0x05 | BS.length rest == size ->
-                    Just $ unlines
-                    [ "address style:    " <> "Jormungandr"
-                    , "address type:     " <> "account"
-                    , "stake reference:  " <> "none"
-                    , "account key:      " <> base16 (BS.take size rest)
-                    , "network tag:      " <> show network
+                    Just $ Json.object
+                    [ "address_style"   .= Json.String "Jormungandr"
+                    , "address_type"    .= Json.String "account"
+                    , "stake_reference" .= Json.String "none"
+                    , "account_key"     .= base16 (BS.take size rest)
+                    , "network_tag"     .= network
                     ]
                 0x06 | BS.length rest == size ->
-                    Just $ unlines
-                    [ "address style:    " <> "Jormungandr"
-                    , "address type:     " <> "multisig"
-                    , "stake reference:  " <> "none"
-                    , "merkle root:      " <> base16 (BS.take size rest)
-                    , "network tag:      " <> show network
+                    Just $ Json.object
+                    [ "address_style"   .= Json.String "Jormungandr"
+                    , "address_type"    .= Json.String "multisig"
+                    , "stake_reference" .= Json.String "none"
+                    , "merkle_root"     .= base16 (BS.take size rest)
+                    , "network_tag"     .= network
                     ]
                 _ ->
                     Nothing

--- a/src/Command.hs
+++ b/src/Command.hs
@@ -30,7 +30,7 @@ import Options.Applicative
     , subparser
     )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, hsep, string, vsep )
 import System.Console.ANSI
     ( hSupportsANSIWithoutEmulation )
 import System.IO
@@ -52,13 +52,15 @@ data CLI
 cli :: ParserInfo CLI
 cli = info (helper <*> parser) $ mempty
     <> progDesc "cardano-addresses"
-    <> footerDoc (Just $ string $ mconcat
-        [ "💡 Need auto-completion?\n\n"
-        , "  ↳ source <(cardano-address --bash-completion-script `which cardano-address`)\n"
-        , "\n"
-        , "Or alternatively --fish-completion-script / --zsh-completion-script.\n"
-        , "For a long-term solution, you may want to put this script in the relevant place. e.g.:\n\n"
-        , "  ↳ /etc/bash_completion.d"
+    <> footerDoc (Just $ vsep
+        [ string "💡 Need auto-completion?"
+        , string ""
+        , hsep [string "  ↳", bold $ string "source <(cardano-address --bash-completion-script `which cardano-address`)"]
+        , string ""
+        , string "Or alternatively --fish-completion-script / --zsh-completion-script."
+        , string "For a long-term solution, you may want to put this script in the relevant place. e.g.:"
+        , string ""
+        , hsep [string "  ↳", bold $ string "/etc/bash_completion.d"]
         ])
   where
     parser = subparser $ mconcat

--- a/src/Command/Address.hs
+++ b/src/Command/Address.hs
@@ -20,7 +20,7 @@ import Options.Applicative
     , subparser
     )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, hsep, string, vsep )
 import Prelude hiding
     ( mod )
 
@@ -43,10 +43,12 @@ mod :: (Cmd -> parent) -> Mod CommandFields parent
 mod liftCmd = command "address" $
     info (helper <*> fmap liftCmd parser) $ mempty
         <> progDesc "About addresses"
-        <> footerDoc (Just $ string $ mconcat
-            [ "Integrating with Byron?\n  ↳ Look at 'bootstrap'."
-            , "\n\n"
-            , "Integrating with Shelley?\n  ↳ Look at 'payment' & 'delegation'."
+        <> footerDoc (Just $ vsep
+            [ string "Integrating with Byron?"
+            , hsep [ string "  ↳ Look at", bold $ string "'bootstrap'", string "." ]
+            , string ""
+            , string "Integrating with Shelley?"
+            , hsep [ string "  ↳ Look at", bold $ string "'payment'", string "&", bold $ string "'delegation'", string "." ]
             ])
   where
     parser = subparser $ mconcat

--- a/src/Command/Address/Bootstrap.hs
+++ b/src/Command/Address/Bootstrap.hs
@@ -35,7 +35,7 @@ import Options.Applicative.Derivation
 import Options.Applicative.Discrimination
     ( NetworkTag (..), networkTagOpt )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, indent, string, vsep )
 import Options.Applicative.Style
     ( Style (..) )
 import System.IO
@@ -60,18 +60,17 @@ mod liftCmd = command "bootstrap" $
     info (helper <*> fmap liftCmd parser) $ mempty
         <> progDesc "Create a bootstrap address"
         <> header "Those addresses, now deprecated, were used during the Byron era."
-        <> footerDoc (Just $ string $ mconcat
-            [ "Example:\n"
-            , "  $ cardano-address recovery-phrase generate --size 12 \\\n"
-            , "  | cardano-address key from-recovery-phrase Byron > root.prv\n"
-            , "\n"
-            , "  $ cat root.prv \\\n"
-            , "  | cardano-address key child 14H/42H > addr.prv\n"
-            , "  | cardano-address key public \\\n"
-            , "  | cardano-address address bootstrap $(cat root.prv | cardano-address key public) \\\n"
-            , "      --network-tag 764824073 --path 14H/42H\n"
-            , "\n"
-            , "  DdzFFzCqrht2KG1vWt5WGhVC9Ezyu32RgB5M2DocdZ6BQU6zj69LSqksDmdM..."
+        <> footerDoc (Just $ vsep
+            [ string "Example:"
+            , indent 2 $ bold $ string "$ cardano-address recovery-phrase generate --size 12 \\"
+            , indent 4 $ bold $ string "| cardano-address key from-recovery-phrase Byron > root.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat root.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key child 14H/42H > addr.prv"
+            , indent 4 $ bold $ string "| cardano-address key public \\"
+            , indent 4 $ bold $ string "| cardano-address address bootstrap $(cat root.prv | cardano-address key public) \\"
+            , indent 8 $ bold $ string "--network-tag 764824073 --path 14H/42H"
+            , indent 2 $ string "DdzFFzCqrht2KG1vWt5WGhVC9Ezyu32RgB5M2DocdZ6BQU6zj69LSqksDmdM..."
             ])
   where
     parser = Cmd

--- a/src/Command/Address/Delegation.hs
+++ b/src/Command/Address/Delegation.hs
@@ -24,7 +24,7 @@ import Options.Applicative
 import Options.Applicative.Derivation
     ( xpubArg )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, indent, string, vsep )
 import System.IO
     ( stdin, stdout )
 import System.IO.Extra
@@ -43,25 +43,24 @@ mod :: (Cmd -> parent) -> Mod CommandFields parent
 mod liftCmd = command "delegation" $
     info (helper <*> fmap liftCmd parser) $ mempty
         <> progDesc "Create a delegation address"
-        <> footerDoc (Just $ string $ mconcat
-            [ "The payment address is read from stdin.\n"
-            , "\n"
-            , "Example:\n"
-            , "  $ cardano-address recovery-phrase generate --size 15 \\\n"
-            , "  | cardano-address key from-recovery-phrase Shelley > root.prv\n"
-            , "\n"
-            , "  $ cat root.prv \\\n"
-            , "  | cardano-address key child 1852H/1815H/0H/2/0 > stake.prv\n"
-            , "\n"
-            , "  $ cat root.prv \\\n"
-            , "  | cardano-address key child 1852H/1815H/0H/0/0 > addr.prv\n"
-            , "\n"
-            , "  $ cat addr.prv \\\n"
-            , "  | cardano-address key public \\\n"
-            , "  | cardano-address address payment --network-tag 0 \\\n"
-            , "  | cardano-address address delegation $(cat stake.prv | cardano-address key public)\n"
-            , "\n"
-            , "  addr1qpj2d4dqzds5p3mmlu95v9pex2d72cdvyjh2u3dtj4yqesv27k..."
+        <> footerDoc (Just $ vsep
+            [ string "The payment address is read from stdin."
+            , string ""
+            , string "Example:"
+            , indent 2 $ bold $ string "$ cardano-address recovery-phrase generate --size 15 \\"
+            , indent 4 $ bold $ string "| cardano-address key from-recovery-phrase Shelley > root.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat root.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key child 1852H/1815H/0H/2/0 > stake.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat root.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key child 1852H/1815H/0H/0/0 > addr.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat addr.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key public \\"
+            , indent 4 $ bold $ string "| cardano-address address payment --network-tag 0 \\"
+            , indent 4 $ bold $ string "| cardano-address address delegation $(cat stake.prv | cardano-address key public)"
+            , indent 2 $ string "addr1qpj2d4dqzds5p3mmlu95v9pex2d72cdvyjh2u3dtj4yqesv27k..."
             ])
   where
     parser = Cmd

--- a/src/Command/Address/Inspect.hs
+++ b/src/Command/Address/Inspect.hs
@@ -27,7 +27,7 @@ import Control.Applicative
 import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, helper, info, progDesc )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, indent, string, vsep )
 import System.IO
     ( stdin, stdout )
 import System.IO.Extra
@@ -44,22 +44,22 @@ mod :: (Cmd -> parent) -> Mod CommandFields parent
 mod liftCmd = command "inspect" $
     info (helper <*> fmap liftCmd parser) $ mempty
         <> progDesc "Show information about an address"
-        <> footerDoc (Just $ string $ mconcat
-            [ "The address is read from stdin.\n"
-            , "\n"
-            , "Example:\n"
-            , "  $ cat addr.prv \\\n"
-            , "  | cardano-address key public \\\n"
-            , "  | cardano-address address payment --network-tag 0 \\\n"
-            , "  | cardano-address address delegation $(cat stake.prv | cardano-address key public) \\\n"
-            , "  | cardano-address address inspect\n"
-            , "  {\n"
-            , "      \"stake_reference\": \"by value\",\n"
-            , "      \"stake_key_hash\": \"6b542d6da35e6c95d95a33c6f66ec482d3f4caf3ad35e2ede09cf827\",\n"
-            , "      \"address_style\": \"Shelley\",\n"
-            , "      \"spending_key_hash\": \"44bc4f524f49a78a9c8a45b882d8710cb9254b3da6a978d50dc9b870\",\n"
-            , "      \"network_tag\": 0\n"
-            , "  }\n"
+        <> footerDoc (Just $ vsep
+            [ string "The address is read from stdin."
+            , string ""
+            , string "Example:"
+            , indent 2 $ bold $ string "$ cat addr.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key public \\"
+            , indent 4 $ bold $ string "| cardano-address address payment --network-tag 0 \\"
+            , indent 4 $ bold $ string "| cardano-address address delegation $(cat stake.prv | cardano-address key public) \\"
+            , indent 4 $ bold $ string "| cardano-address address inspect"
+            , indent 2 $ string "{"
+            , indent 2 $ string "    \"address_style\": \"Shelley\","
+            , indent 2 $ string "    \"stake_reference\": \"by value\","
+            , indent 2 $ string "    \"stake_key_hash\": \"6b542d6da35e6c95d95a33c6f66ec482d3f4caf3ad35e2ede09cf827\","
+            , indent 2 $ string "    \"spending_key_hash\": \"44bc4f524f49a78a9c8a45b882d8710cb9254b3da6a978d50dc9b870\","
+            , indent 2 $ string "    \"network_tag\": 0"
+            , indent 2 $ string "}"
             ])
   where
     parser = pure Inspect

--- a/src/Command/Address/Payment.hs
+++ b/src/Command/Address/Payment.hs
@@ -22,7 +22,7 @@ import Options.Applicative
 import Options.Applicative.Discrimination
     ( NetworkTag (..), networkTagOpt )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, indent, string, vsep )
 import Options.Applicative.Style
     ( Style (..) )
 import System.IO
@@ -44,19 +44,18 @@ mod liftCmd = command "payment" $
     info (helper <*> fmap liftCmd parser) $ mempty
         <> progDesc "Create a payment address"
         <> header "Payment addresses carry no delegation rights whatsoever."
-        <> footerDoc (Just $ string $ mconcat
-            [ "Example:\n"
-            , "  $ cardano-address recovery-phrase generate --size 15 \\\n"
-            , "  | cardano-address key from-recovery-phrase Shelley > root.prv\n"
-            , "\n"
-            , "  $ cat root.prv \\\n"
-            , "  | cardano-address key child 1852H/1815H/0H/0/0 > addr.prv\n"
-            , "\n"
-            , "  $ cat addr.prv \\\n"
-            , "  | cardano-address key public \\\n"
-            , "  | cardano-address address payment --network-tag 0\n"
-            , "\n"
-            , "  addr1vrcmygdgp7v3mhz78v8kdsfru0y9wysnr9pgvvgmdqx2w0qrg8swg"
+        <> footerDoc (Just $ vsep
+            [ string "Example:"
+            , indent 2 $ bold $ string "$ cardano-address recovery-phrase generate --size 15 \\"
+            , indent 4 $ bold $ string "| cardano-address key from-recovery-phrase Shelley > root.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat root.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key child 1852H/1815H/0H/0/0 > addr.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat addr.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key public \\"
+            , indent 4 $ bold $ string "| cardano-address address payment --network-tag 0"
+            , indent 2 $ string "addr1vrcmygdgp7v3mhz78v8kdsfru0y9wysnr9pgvvgmdqx2w0qrg8swg"
             ])
   where
     parser = Cmd

--- a/src/Command/Address/Pointer.hs
+++ b/src/Command/Address/Pointer.hs
@@ -34,7 +34,7 @@ import Options.Applicative
     , progDesc
     )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, indent, string, vsep )
 import System.IO
     ( stdin, stdout )
 import System.IO.Extra
@@ -57,22 +57,21 @@ mod liftCmd = command "pointer" $
         <> progDesc "Create a pointer address"
         <> header "Create addresses with a pointer that indicate the position \
             \of a registered stake address on the chain."
-        <> footerDoc (Just $ string $ mconcat
-            [ "The payment address is read from stdin.\n"
-            , "\n"
-            , "Example:\n"
-            , "  $ cardano-address recovery-phrase generate --size 15 \\\n"
-            , "  | cardano-address key from-recovery-phrase Shelley > root.prv\n"
-            , "\n"
-            , "  $ cat root.prv \\\n"
-            , "  | cardano-address key child 1852H/1815H/0H/0/0 > addr.prv\n"
-            , "\n"
-            , "  $ cat addr.prv \\\n"
-            , "  | cardano-address key public \\\n"
-            , "  | cardano-address address payment --network-tag 0\\\n"
-            , "  | cardano-address address pointer 42 14 0\n"
-            , "\n"
-            , "  addr1grq8e0smk44luyl897e24gn6qfkx4ax734r6pzq29zcew032pcqqef7zzu"
+        <> footerDoc (Just $ vsep
+            [ string "The payment address is read from stdin."
+            , string ""
+            , string "Example:"
+            , indent 2 $ bold $ string "$ cardano-address recovery-phrase generate --size 15 \\"
+            , indent 4 $ bold $ string "| cardano-address key from-recovery-phrase Shelley > root.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat root.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key child 1852H/1815H/0H/0/0 > addr.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat addr.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key public \\"
+            , indent 4 $ bold $ string "| cardano-address address payment --network-tag 0\\"
+            , indent 4 $ bold $ string "| cardano-address address pointer 42 14 0"
+            , indent 2 $ string "addr1grq8e0smk44luyl897e24gn6qfkx4ax734r6pzq29zcew032pcqqef7zzu"
             ])
   where
     parser = Cmd

--- a/src/Command/Key.hs
+++ b/src/Command/Key.hs
@@ -23,7 +23,7 @@ import Options.Applicative
     , subparser
     )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, indent, string, vsep )
 
 import qualified Command.Key.Child as Child
 import qualified Command.Key.FromRecoveryPhrase as FromRecoveryPhrase
@@ -41,27 +41,29 @@ mod :: (Cmd -> parent) -> Mod CommandFields parent
 mod liftCmd = command "key" $
     info (helper <*> fmap liftCmd parser) $ mempty
         <> progDesc "About public/private keys"
-        <> footerDoc (Just $ string $ mconcat
-            [ "Example:\n\n"
-            , "  $ cardano-address recovery-phrase generate --size 15 \\\n"
-            , "  | cardano-address key from-recovery-phrase Shelley > root.prv \n"
-            , "  \n"
-            , "  $ cat root.prv \\\n"
-            , "  | cardano-address key child 1852H/1815H/0H \\\n"
-            , "  | tee acct.prv \\\n"
-            , "  | cardano-address key public > acct.pub \n"
-            , "  \n"
-            , "  $ cat acct.prv | cardano-address key inspect\n"
-            , "  key type:     private\n"
-            , "  extended key: 586063c612e8eaa3d807c444c1e5c1630e5a486071edbe18fd900f68236d96438d5f4e3...\n"
-            , "  chain code:   09b9b219ab1df2bce6597704009cc8ced2fccc9655ff0aebf409b55f0a36ee96\n"
-            , "  \n"
-            , "  $ cat acct.pub | cardano-address key inspect\n"
-            , "  key type:     public\n"
-            , "  extended key: 406f0caac3a0977684aa4b7182ff62612aa4fbe576c1ba0b9a41c7b11f4a1167\n"
-            , "  chain code:   09b9b219ab1df2bce6597704009cc8ced2fccc9655ff0aebf409b55f0a36ee96\n"
-            , "  \n"
-            , "  $ cat acct.pub | cardano-address key child 0/0 > addr.pub"
+        <> footerDoc (Just $ vsep
+            [ string "Example:"
+            , indent 2 $ bold $ string "$ cardano-address recovery-phrase generate --size 15 \\"
+            , indent 4 $ bold $ string "| cardano-address key from-recovery-phrase Shelley > root.prv"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cat root.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key child 1852H/1815H/0H \\"
+            , indent 4 $ bold $ string "| tee acct.prv \\"
+            , indent 4 $ bold $ string "| cardano-address key public > acct.pub"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cardano-address key inspect <<< $(cat acct.prv)"
+            , indent 2 $ string "{"
+            , indent 2 $ string "    \"key_type\": \"private\","
+            , indent 2 $ string "    \"chain_code\": \"67bef6f80df02c7452e20e76ffb4bb57cae8aac2adf042b21a6b19e4f7b1f511\","
+            , indent 2 $ string "    \"extended_key\": \"90ead3efad7aacac242705ede323665387f49ed847bed025eb333708ccf6aa54403482a867daeb18f38c57d6cddd7e6fd6aed4a3209f7425a3d1c5d9987a9c5f\""
+            , indent 2 $ string "}"
+            , indent 2 $ string ""
+            , indent 2 $ bold $ string "$ cardano-address key inspect <<< $(cat acct.pub)"
+            , indent 2 $ string "{"
+            , indent 2 $ string "    \"key_type\": \"public\","
+            , indent 2 $ string "    \"chain_code\": \"67bef6f80df02c7452e20e76ffb4bb57cae8aac2adf042b21a6b19e4f7b1f511\","
+            , indent 2 $ string "    \"extended_key\": \"d306350ee88f51fb710252e27f0c40006c58e994761b383e02d400e2be59b3cc\""
+            , indent 2 $ string "}"
             ])
   where
     parser = subparser $ mconcat

--- a/src/Command/Key/FromRecoveryPhrase.hs
+++ b/src/Command/Key/FromRecoveryPhrase.hs
@@ -23,7 +23,7 @@ import Options.Applicative
 import Options.Applicative.Encoding
     ( Encoding, encodingOpt )
 import Options.Applicative.Help.Pretty
-    ( string )
+    ( bold, indent, string, vsep )
 import Options.Applicative.Style
     ( Style, generateRootKey, styleArg )
 import System.IO
@@ -41,12 +41,12 @@ mod :: (Cmd -> parent) -> Mod CommandFields parent
 mod liftCmd = command "from-recovery-phrase" $
     info (helper <*> fmap liftCmd parser) $ mempty
         <> progDesc "Convert a recovery phrase to an extended private key"
-        <> footerDoc (Just $ string $ mconcat
-            [ "The recovery phrase is read from stdin."
-            , "\n\n"
-            , "Example:\n\n"
-            , "  $ cardano-address recovery-phrase generate \\\n"
-            , "  | cardano-address key from-recovery-phrase icarus \\\n"
+        <> footerDoc (Just $ vsep
+            [ string "The recovery phrase is read from stdin."
+            , string ""
+            , string "Example:"
+            , indent 2 $ bold $ string "$ cardano-address recovery-phrase generate \\"
+            , indent 2 $ bold $ string "| cardano-address key from-recovery-phrase Icarus"
             ])
   where
     parser = FromRecoveryPhrase

--- a/src/Options/Applicative/Derivation.hs
+++ b/src/Options/Applicative/Derivation.hs
@@ -53,7 +53,17 @@ import Data.List
 import Data.Word
     ( Word32 )
 import Options.Applicative
-    ( Parser, argument, eitherReader, flag, help, long, metavar, option )
+    ( Parser
+    , argument
+    , completer
+    , eitherReader
+    , flag
+    , help
+    , listCompleter
+    , long
+    , metavar
+    , option
+    )
 import Safe
     ( readEitherSafe )
 
@@ -88,7 +98,8 @@ derivationPathArg = argument (eitherReader derivationPathFromString) $ mempty
     <> metavar "DERIVATION-PATH"
     <> help
         "Slash-separated derivation path. Hardened indexes are marked with a \
-        \'H' (e.g. 44H/1815H/0H/0)."
+        \'H' (e.g. 1852H/1815H/0H/0)."
+    <> completer (listCompleter ["1852H/1815H/0H/", "44H/1815H/0H/"])
 
 derivationPathOpt :: Parser DerivationPath
 derivationPathOpt = option (eitherReader derivationPathFromString) $ mempty
@@ -96,7 +107,8 @@ derivationPathOpt = option (eitherReader derivationPathFromString) $ mempty
     <> long "path"
     <> help
         "Slash-separated derivation path. Hardened indexes are marked with a \
-        \'H' (e.g. 44H/1815H/0H/0)."
+        \'H' (e.g. 1852H/1815H/0H/0)."
+    <> completer (listCompleter ["1852H/1815H/0H/", "44H/1815H/0H/"])
 
 --
 -- Derivation Index

--- a/src/Options/Applicative/Discrimination.hs
+++ b/src/Options/Applicative/Discrimination.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 {-# OPTIONS_HADDOCK hide #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
@@ -15,7 +17,7 @@ import Prelude
 import Cardano.Address
     ( NetworkTag (..) )
 import Options.Applicative
-    ( Parser, auto, helpDoc, long, metavar, option )
+    ( Parser, auto, completer, helpDoc, listCompleter, long, metavar, option )
 import Options.Applicative.Help.Pretty
     ( string, vsep )
 import Options.Applicative.Style
@@ -35,6 +37,7 @@ networkTagOpt style = option (NetworkTag <$> auto) $ mempty
     <> metavar "NETWORK-TAG"
     <> long "network-tag"
     <> helpDoc  (Just (vsep (string <$> doc style)))
+    <> completer (listCompleter $ show <$> tagsFor style)
   where
     doc style' =
         [ "A tag which identifies a Cardano network."
@@ -56,4 +59,20 @@ networkTagOpt style = option (NetworkTag <$> auto) $ mempty
             [ "┌ Shelley ─────────────────"
             , "│ mainnet: " <> show (unNetworkTag Shelley.shelleyMainnet)
             , "│ testnet: " <> show (unNetworkTag Shelley.shelleyTestnet)
+            ]
+
+    tagsFor = \case
+        Byron ->
+            [ unNetworkTag (snd Byron.byronMainnet)
+            , unNetworkTag (snd Byron.byronStaging)
+            , unNetworkTag (snd Byron.byronTestnet)
+            ]
+        Icarus ->
+            tagsFor Byron
+        Jormungandr ->
+            [ unNetworkTag Jormungandr.incentivizedTestnet
+            ]
+        Shelley ->
+            [ unNetworkTag Shelley.shelleyMainnet
+            , unNetworkTag Shelley.shelleyTestnet
             ]

--- a/src/Options/Applicative/MnemonicSize.hs
+++ b/src/Options/Applicative/MnemonicSize.hs
@@ -24,8 +24,10 @@ import GHC.Generics
     ( Generic )
 import Options.Applicative
     ( Parser
+    , completer
     , eitherReader
     , help
+    , listCompleter
     , long
     , metavar
     , option
@@ -54,9 +56,10 @@ mnemonicSizeFromString str =
             <> intercalate ", " sizeStrs
             <> "."
   where
-    sizes    = enumerate
-    sizeMap  = sizeStrs `zip` sizes
-    sizeStrs = mnemonicSizeToString <$> sizes
+    sizeMap  = sizeStrs `zip` enumerate
+
+sizeStrs :: [String]
+sizeStrs = mnemonicSizeToString <$> enumerate
 
 --
 -- Applicative Parser
@@ -69,3 +72,4 @@ mnemonicSizeOpt = option (eitherReader mnemonicSizeFromString) $ mempty
     <> help "Number of mnemonic words to generate. Must be a multiple of 3."
     <> value MS_15
     <> showDefaultWith mnemonicSizeToString
+    <> completer (listCompleter sizeStrs)

--- a/src/Options/Applicative/Style.hs
+++ b/src/Options/Applicative/Style.hs
@@ -26,7 +26,7 @@ import Data.Char
 import Data.List
     ( intercalate )
 import Options.Applicative
-    ( Parser, argument, eitherReader, help, metavar )
+    ( Parser, argument, completer, eitherReader, help, listCompleter, metavar )
 
 import qualified Cardano.Address.Style.Byron as Byron
 import qualified Cardano.Address.Style.Icarus as Icarus
@@ -76,10 +76,13 @@ generateRootKey mw = \case
 styleArg :: Parser Style
 styleArg = argument (eitherReader reader) $ mempty
     <> metavar "STYLE"
-    <> help styles
+    <> help styles'
+    <> completer (listCompleter styles)
   where
-    styles :: String
-    styles = intercalate " | " $ show @Style <$> [minBound .. maxBound]
+    styles :: [String]
+    styles = show @Style <$> [minBound .. maxBound]
+
+    styles' = intercalate " | " styles
 
     reader :: String -> Either String Style
     reader str = case toLower <$> str of
@@ -87,4 +90,4 @@ styleArg = argument (eitherReader reader) $ mempty
         "icarus"      -> Right Icarus
         "jormungandr" -> Right Jormungandr
         "shelley"     -> Right Shelley
-        _             -> Left $ "Unknown style; expecting one of " <> styles
+        _             -> Left $ "Unknown style; expecting one of " <> styles'

--- a/src/System/IO/Extra.hs
+++ b/src/System/IO/Extra.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_HADDOCK hide #-}

--- a/test/Command/Address/InspectSpec.hs
+++ b/test/Command/Address/InspectSpec.hs
@@ -48,9 +48,9 @@ spec = describeCmd [ "address", "inspect" ] $ do
 specInspectAddress :: [String] -> String -> SpecWith ()
 specInspectAddress mustHave addr = it addr $ do
     out <- cli [ "address", "inspect" ] addr
-    out `shouldContain` "address style:"
-    out `shouldContain` "stake reference:"
-    out `shouldContain` "network tag:"
+    out `shouldContain` "address_style"
+    out `shouldContain` "stake_reference"
+    out `shouldContain` "network_tag"
     forM_ mustHave (shouldContain out)
 
 specInspectMalformed :: String -> SpecWith ()


### PR DESCRIPTION
- 0c4e5bcce52c6d746db29aa3d3043eb1a38f65df
  :round_pushpin: **return structured JSON instead of pretty string for address introspection**
  So that the output can be easily parsed and used by another software.


TODO: `key inspect` as well for consistency.