### PR TITLE
Force input/output text encoding to be utf-8

### DIFF
--- a/src/Command.hs
+++ b/src/Command.hs
@@ -34,7 +34,15 @@ import Options.Applicative.Help.Pretty
 import System.Console.ANSI
     ( hSupportsANSIWithoutEmulation )
 import System.IO
-    ( BufferMode (..), Handle, hSetBuffering, stderr, stdout )
+    ( BufferMode (..)
+    , Handle
+    , hSetBuffering
+    , hSetEncoding
+    , mkTextEncoding
+    , stderr
+    , stdin
+    , stdout
+    )
 import System.IO.Extra
     ( prettyIOException, progName )
 
@@ -85,10 +93,13 @@ run = handle prettyIOException . \case
 parse :: IO CLI
 parse = customExecParser (prefs showHelpOnEmpty) cli
 
--- | Enable ANSI colors on Windows and correct output buffering
+-- | Enable ANSI colors on Windows and correct output buffering.
+-- Force input/output text encoding to be utf-8 regardless of system setting.
 setup :: IO ()
-setup =
+setup = do
     mapM_ hSetup [stderr, stdout]
+    utf8' <- mkTextEncoding "UTF-8//TRANSLIT"
+    mapM_ (`hSetEncoding` utf8') [stdin, stdout, stderr]
   where
     hSetup :: Handle -> IO ()
     hSetup h = do


### PR DESCRIPTION
Related to #41.

I didn't test anything yet but the same code works in cardano-wallet.

Depending on the test cases, it might also need `hSetEncoding utf8 stdout` in `test/Main.hs` so that tests pass (annoying to do with hspec-discover).
