### PR TITLE
Windows Issues / Testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       id: variables
       run: |
         echo ::set-output name=pkg_name::$(cat *.cabal | grep "name:" | sed "s/name:\s*\(.*\)/\1/")
-        echo ::set-output name=cache_key::$(md5sum stack.yaml | awk '{print $1}')
+        echo ::set-output name=cache_key::${{ hashFiles('stack.yaml') }}
 
     - name: 💾 Cache Dependencies
       id: cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Continuous Integration (Linux)
 
 on:
   pull_request:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,38 @@
+name: Continuous Integration (Windows)
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches: [ "master" ]
+    tags: [ "*.*.*" ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v1
+
+    - name: 🧰 Setup Stack
+      uses: mstksg/setup-stack@69e4283f
+
+    - name: 💾 Cache Dependencies
+      id: cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.stack
+        key: ${{ matrix.os }}-${{ hashFiles('stack.yaml') }}
+
+    - name: 📸 Build Snapshot
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        stack --no-terminal test --bench --only-snapshot
+
+    - name: 🔨 Build & Test
+      run: |
+        stack --no-terminal test --bench --haddock --no-haddock-deps --no-run-benchmarks --flag cardano-addresses:release

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,7 +2,10 @@ module Main where
 
 import Prelude
 
+import Command
+    ( withUtf8Encoding )
+
 import qualified Command as CLI
 
 main :: IO ()
-main = CLI.setup >> CLI.parse >>= CLI.run
+main = withUtf8Encoding (CLI.setup >> CLI.parse >>= CLI.run)

--- a/cardano-addresses.cabal
+++ b/cardano-addresses.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 914290d4127de4ecec3de55cab527b0bac04bd20033e880e4da520a1879ef2ab
+-- hash: 1bf8e783e1cb5c31b6ef7ac957c0fca1a9fa8daaaf00a362cd64af98ff64392c
 
 name:           cardano-addresses
 version:        1.0.0
@@ -80,6 +80,7 @@ library
     , bytestring
     , cardano-crypto
     , cborg
+    , code-page
     , cryptonite
     , deepseq
     , digest
@@ -145,6 +146,10 @@ test-suite unit
       test
   default-extensions: NoImplicitPrelude
   ghc-options: -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  build-tools:
+      cardano-address
+  build-tool-depends:
+      hspec-discover:hspec-discover
   build-depends:
       QuickCheck
     , base >=4.7 && <5

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ library:
   - bytestring
   - cardano-crypto
   - cborg
+  - code-page
   - cryptonite
   - deepseq
   - digest
@@ -94,6 +95,9 @@ tests:
     - condition: flag(release)
       ghc-options:
       - -Werror
+    build-tools:
+    - hspec-discover
+    - cardano-address
     dependencies:
     - base58-bytestring
     - bech32

--- a/src/Command.hs
+++ b/src/Command.hs
@@ -10,6 +10,9 @@ module Command
     , setup
     , parse
     , run
+
+    -- * I/O Fix
+    , withUtf8Encoding
     ) where
 
 import Prelude
@@ -86,7 +89,7 @@ cli = info (helper <*> parser) $ mempty
 
 -- | Run a given command
 run :: CLI -> IO ()
-run = withUtf8Encoding . handle prettyIOException . \case
+run = handle prettyIOException . \case
     RecoveryPhrase sub -> RecoveryPhrase.run sub
     Key sub -> Key.run sub
     Address sub -> Address.run sub
@@ -98,7 +101,7 @@ parse = customExecParser (prefs showHelpOnEmpty) cli
 -- | Enable ANSI colors on Windows and correct output buffering
 setup :: IO ()
 setup =
-    mapM_ hSetup [stderr, stdout]
+    mapM_ hSetup [stderr, stdout, stdin]
   where
     hSetup :: Handle -> IO ()
     hSetup h = do

--- a/src/Options/Applicative/Discrimination.hs
+++ b/src/Options/Applicative/Discrimination.hs
@@ -17,11 +17,21 @@ import Prelude
 import Cardano.Address
     ( NetworkTag (..) )
 import Options.Applicative
-    ( Parser, auto, completer, helpDoc, listCompleter, long, metavar, option )
+    ( Parser
+    , completer
+    , eitherReader
+    , helpDoc
+    , listCompleter
+    , long
+    , metavar
+    , option
+    )
 import Options.Applicative.Help.Pretty
     ( string, vsep )
 import Options.Applicative.Style
     ( Style (..) )
+import Text.Read
+    ( readMaybe )
 
 import qualified Cardano.Address.Style.Byron as Byron
 import qualified Cardano.Address.Style.Jormungandr as Jormungandr
@@ -33,7 +43,7 @@ import qualified Cardano.Address.Style.Shelley as Shelley
 
 -- | Parse a 'NetworkTag' from the command-line, as an option
 networkTagOpt :: Style -> Parser NetworkTag
-networkTagOpt style = option (NetworkTag <$> auto) $ mempty
+networkTagOpt style = option (eitherReader reader) $ mempty
     <> metavar "NETWORK-TAG"
     <> long "network-tag"
     <> helpDoc  (Just (vsep (string <$> doc style)))
@@ -76,3 +86,9 @@ networkTagOpt style = option (NetworkTag <$> auto) $ mempty
             [ unNetworkTag Shelley.shelleyMainnet
             , unNetworkTag Shelley.shelleyTestnet
             ]
+
+    reader =
+        maybe
+            (Left "Invalid network tag. Must be a integer value.")
+            (Right . NetworkTag)
+            . readMaybe

--- a/test/Cardano/Address/Style/ByronSpec.hs
+++ b/test/Cardano/Address/Style/ByronSpec.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}

--- a/test/Command/Address/BootstrapSpec.hs
+++ b/test/Command/Address/BootstrapSpec.hs
@@ -53,7 +53,7 @@ specInvalidNetwork :: String -> SpecWith ()
 specInvalidNetwork networkTag = it ("invalid network " <> networkTag) $ do
     (out, err) <- cli [ "address", "bootstrap", "--network-tag", networkTag ] ""
     out `shouldBe` ""
-    err `shouldContain` "--network-tag: cannot parse value"
+    err `shouldContain` "Invalid network tag. Must be a integer value."
     err `shouldContain` "Usage"
 
 defaultPhrase :: [String]

--- a/test/Command/Address/PaymentSpec.hs
+++ b/test/Command/Address/PaymentSpec.hs
@@ -37,7 +37,7 @@ specMalformedNetwork networkTag = it ("malformed network " <> networkTag) $ do
         >>= cli [ "key", "public" ]
         >>= cli [ "address", "payment", "--network-tag", networkTag ]
     out `shouldBe` ""
-    err `shouldContain` "--network-tag: cannot parse value"
+    err `shouldContain` "Invalid network tag. Must be a integer value."
     err `shouldContain` "Usage"
 
 specInvalidNetwork :: String -> SpecWith ()


### PR DESCRIPTION
- b7ac636ea8738fe86e0836f90f946efefe6b1cf3
  :round_pushpin: **use pre-define 'hashFiles' function for cache**
  
- 9d633beaea9f63a486ac8c751ebf35fc622349db
  :round_pushpin: **add workflow for Windows**
  
- d824f16fb34edb00cec24adf65091312821f38f4
  :round_pushpin: **force UTF-8 encoding, with Windows tricks**
  
- 3df6364cec050ee1ce7c5f2e3432952b18bb3637
  :round_pushpin: **do not spit back malformed network tag when given gibberish**
  It's usually not a good idea to spit back to users something that we failed to parse in the first place. Instead, we should print what we would have expected.

- 598c7c8536d79e7cb0b3fd93919ed925a0490347
  :round_pushpin: **remove unused pragma (new HLint is better at catching those)**
