### PR TITLE
32-byte digest for script hashes

### DIFF
--- a/test/Command/Address/InspectSpec.hs
+++ b/test/Command/Address/InspectSpec.hs
@@ -45,6 +45,11 @@ spec = describeCmd [ "address", "inspect" ] $ do
     specInspectInvalid
         "79467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65"
 
+    -- 28-byte long script hash
+    specInspectInvalid
+        "addr1y9xup4n8cyckl7zw2u33pcn9ake3xvzy3vmtw9u79rw5r8ky\
+        \6pru7d6jgn4t89vy3n3d68sx5uej906uwpp83dtefn6qv4hscd"
+
 specInspectAddress :: [String] -> String -> SpecWith ()
 specInspectAddress mustHave addr = it addr $ do
     out <- cli [ "address", "inspect" ] addr


### PR DESCRIPTION
- f41c20106a3e917ec1707d6a2867860a033d8aea
  :round_pushpin: **expect 32-byte script hash in addresses**
    There has been a little quirk that made it to the final ledger implementation. Script hashes ended up being 32-byte digests instead of 28-byte like the rest. That is unfortunate and this commits deals with that.

- ce5a8ffa9b9acd2cb1da079df582c39de7848d15
  :round_pushpin: **add regression test showing that addresses with 28-byte long script hashes can't be inspected correctly**
