### PR TITLE
Increase default mnemonic phrase length.

### DIFF
--- a/command-line/lib/Options/Applicative/MnemonicSize.hs
+++ b/command-line/lib/Options/Applicative/MnemonicSize.hs
@@ -70,6 +70,6 @@ mnemonicSizeOpt = option (eitherReader mnemonicSizeFromString) $ mempty
     <> long "size"
     <> metavar "INT"
     <> help "Number of mnemonic words to generate. Must be a multiple of 3."
-    <> value MS_15
+    <> value MS_24
     <> showDefaultWith mnemonicSizeToString
     <> completer (listCompleter sizeStrs)

--- a/command-line/test/Command/RecoveryPhrase/GenerateSpec.hs
+++ b/command-line/test/Command/RecoveryPhrase/GenerateSpec.hs
@@ -20,7 +20,7 @@ spec = describeCmd ["recovery-phrase", "generate"] $ do
 specDefaultSize :: SpecWith ()
 specDefaultSize = it "ø; default size" $ do
     out <- cli ["recovery-phrase", "generate"] mempty
-    length (words out) `shouldBe` 15
+    length (words out) `shouldBe` 24
 
 specSpecificSize :: Int -> SpecWith ()
 specSpecificSize n = it ("--size=" <> show n <> "; valid size") $ do


### PR DESCRIPTION
# Issue Number

#52 

# Overview

This PR increases the default mnemonic phrase length from **15 words** to **24 words**.