### PR TITLE
Readme and example updates for addr_test and stake_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ xpub16y4vhpyuj2t84gh2qfe3ydng3wc37yqzxev6gce380fvvg47ye8um3dm3wn5a64gt7l0fh5j6sj
   | cardano-address key public \
   | cardano-address address payment --network-tag 0
 
-  addr1vrcmygdgp7v3mhz78v8kdsfru0y9wysnr9pgvvgmdqx2w0qrg8swg
+  addr_test1vqrlltfahghjxl5sy5h5mvfrrlt6me5fqphhwjqvj5jd88cccqcek
 ```
 </details>
 
@@ -101,8 +101,8 @@ xpub16y4vhpyuj2t84gh2qfe3ydng3wc37yqzxev6gce380fvvg47ye8um3dm3wn5a64gt7l0fh5j6sj
 
   $ cat addr.prv \
   | cardano-address key public \
-  | cardano-address address payment --network-tag 0
-  | cardano-address address delegation $(cat stake.prv | cardano-address key public)"
+  | cardano-address address payment --network-tag 0 \
+  | cardano-address address delegation $(cat stake.prv | cardano-address key public)
   addr1vrcmygdgp7v3mhz78v8kdsfru0y9wysnr9pgvvgmdqx2w0qrg8swg...
 ```
 </details>

--- a/command-line/lib/Command/Address/Payment.hs
+++ b/command-line/lib/Command/Address/Payment.hs
@@ -59,7 +59,7 @@ mod liftCmd = command "payment" $
             , indent 2 $ bold $ string "$ cat addr.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" address payment --network-tag 0"
-            , indent 2 $ string "addr1vrcmygdgp7v3mhz78v8kdsfru0y9wysnr9pgvvgmdqx2w0qrg8swg"
+            , indent 2 $ string "addr_test1vqrlltfahghjxl5sy5h5mvfrrlt6me5fqphhwjqvj5jd88cccqcek"
             ])
   where
     parser = Cmd

--- a/command-line/lib/Command/Address/Reward.hs
+++ b/command-line/lib/Command/Address/Reward.hs
@@ -64,7 +64,7 @@ mod liftCmd = command "stake" $
             , indent 2 $ bold $ string "$ cat stake.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" address stake --network-tag 0"
-            , indent 2 $ string "stake1uqly0fjvrgguywze067gwhsexggtj8rrdnxczgp5vexe8zgxqns3g"
+            , indent 2 $ string "stake_test1uzp7swuxjx7wmpkkvat8kpgrmjl8ze0dj9lytn25qv2tm4g6n5c35"
             ])
   where
     parser = Cmd


### PR DESCRIPTION
I have updated readme and cmdline exmples to include changes for generating `addr_test` and `stake_test1` addresses.

- 437d470e5577c934ad4eec2a7d591a04e3fa4881
  Fix readme examples
  
- 7efc9244dc0dd39610f2fb77aa0a8c2e8f05d03f
  Update cmd-line examples