### PR TITLE
Completely disable RDRAND in cryptonite using a cabal flag

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,3 +9,8 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-crypto
   tag: 2547ad1e80aeabca2899951601079408becbc92c
   --sha256: 1p2kg2w02q5w1cvqzhfhqmxviy4xrzada3mmb096j2n6hfr20kri
+
+package cryptonite
+  -- Using RDRAND instead of /dev/urandom as an entropy source for key
+  -- generation is dubious. Set the flag so we use /dev/urandom by default.
+  flags: -support_rdrand

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,12 @@ extra-deps:
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 2547ad1e80aeabca2899951601079408becbc92c
 
+flags:
+  # Using RDRAND instead of /dev/urandom as an entropy source for key
+  # generation is dubious. Set the flag so we use /dev/urandom by default.
+  cryptonite:
+    support_rdrand: false
+
 # Generate files required by Weeder.
 # See https://github.com/ndmitchell/weeder/issues/53
 ghc-options: {"$locals": -ddump-to-file -ddump-hi}


### PR DESCRIPTION
Relates to [ADP-428](https://jira.iohk.io/browse/ADP-428).

Ensures that RDRAND can never be the sole source of RNG entropy.

To generate mnemonics it goes through cryptonite `Crypto.Random.Entropy.getEntropy`.
Disabling the RDRAND backend will leave just the WinCryptoAPI (windows) and DevRandom, DevURandom backends (not windows).