### PR TITLE
infer bech32 prefix from base address for pointer & delegation

### DIFF
--- a/command-line/test/Command/Address/DelegationSpec.hs
+++ b/command-line/test/Command/Address/DelegationSpec.hs
@@ -14,14 +14,14 @@ import Test.Utils
 spec :: Spec
 spec = describeCmd [ "address", "delegation" ] $ do
     specShelley defaultPhrase "1852H/1815H/0H/2/0"
-        "addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w"
-        "addr1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt\
-        \70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwmnp2v"
+        defaultAddrMainnet
+        "addr1q9therz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwvxwdrt\
+        \70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qdqhgvu"
 
     specShelley defaultPhrase "1852H/1815H/0H/2/0"
-        "addr1vdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0m9a08"
-        "addr1qdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt\
-        \70qlcpeeagscasafhffqsxy36t90ldv06wqrk2q5ggg4z"
+        defaultAddrTestnet
+        "addr_test1qptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwv\
+        \xwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwk2gqr"
 
     specMalformedAddress "💩"
 
@@ -67,16 +67,15 @@ specInvalidAddress addr = it ("invalid address " <> addr) $ do
 
 specMalformedXPub :: String -> SpecWith ()
 specMalformedXPub xpub = it ("malformed xpub " <> xpub) $ do
-    (out, err) <- cli [ "address", "delegation", xpub ] defaultAddr
+    (out, err) <- cli [ "address", "delegation", xpub ] defaultAddrMainnet
     out `shouldBe` ""
     err `shouldContain` "Couldn't detect input encoding?"
 
 specInvalidXPub :: String -> SpecWith ()
 specInvalidXPub xpub = it ("invalid xpub " <> xpub) $ do
-    (out, err) <- cli [ "address", "delegation", xpub ] defaultAddr
+    (out, err) <- cli [ "address", "delegation", xpub ] defaultAddrMainnet
     out `shouldBe` ""
     err `shouldContain` "Failed to convert bytes into a valid extended public key"
-
 
 defaultPhrase :: [String]
 defaultPhrase =
@@ -90,6 +89,10 @@ defaultXPub =
     "xpub1z0lq4d73l4xtk42s3364s2fpn4m5xtuacfkfj4dxxt9uhccvlg6p\
     \amdykgvcna3w4jf6zr3yqenuasug3gp22peqm6vduzrzw8uj6asghxwup"
 
-defaultAddr :: String
-defaultAddr =
-    "addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w"
+defaultAddrMainnet :: String
+defaultAddrMainnet =
+    "addr1v9therz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qgx2curq"
+
+defaultAddrTestnet :: String
+defaultAddrTestnet =
+    "addr_test1vptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qgazvqv9"

--- a/command-line/test/Command/Address/PointerSpec.hs
+++ b/command-line/test/Command/Address/PointerSpec.hs
@@ -13,13 +13,19 @@ import Test.Utils
 
 spec :: Spec
 spec = describeCmd [ "address", "pointer" ] $ do
-    specShelley (1,2,3) defaultAddr
-        "addr1gpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5egpqgpsjej5ck"
+    specShelley (1,2,3) defaultAddrMainnet
+        "addr1g9therz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qgpqgpsyefcgl"
 
-    specShelley (24157,177,42) defaultAddr
-        "addr1gpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5evph3wczvf2jyfghp"
+    specShelley (1,2,3) defaultAddrTestnet
+        "addr_test1gptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qgpqgpsa3x7je"
 
-    specMalformed ("💩","💩","💩") defaultAddr
+    specShelley (24157,177,42) defaultAddrMainnet
+        "addr1g9therz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qvph3wczvf2sg4yzx"
+
+    specShelley (24157,177,42) defaultAddrTestnet
+        "addr_test1gptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qvph3wczvf2lxgdw5"
+
+    specMalformed ("💩","💩","💩") defaultAddrMainnet
 
     specInvalidAddress
         "Ae2tdPwUPEYz6ExfbWubiXPB6daUuhJxikMEb4eXRp5oKZBKZwrbJ2k7EZe"
@@ -51,6 +57,10 @@ specInvalidAddress addr = it ("invalid address " <> addr) $ do
     out `shouldBe` ""
     err `shouldContain` "Only payment addresses can be extended"
 
-defaultAddr :: String
-defaultAddr =
-    "addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w"
+defaultAddrMainnet :: String
+defaultAddrMainnet =
+    "addr1v9therz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qgx2curq"
+
+defaultAddrTestnet :: String
+defaultAddrTestnet =
+    "addr_test1vptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qgazvqv9"

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -46,6 +46,7 @@ module Cardano.Address.Style.Shelley
       -- * Network Discrimination
     , MkNetworkDiscriminantError (..)
     , mkNetworkDiscriminant
+    , inspectNetworkDiscriminant
     , shelleyMainnet
     , shelleyTestnet
 
@@ -706,6 +707,22 @@ mkNetworkDiscriminant
 mkNetworkDiscriminant nTag
     | nTag < 16 =  Right $ NetworkTag $ fromIntegral nTag
     | otherwise = Left $ ErrWrongNetworkTag nTag
+
+-- | Retrieve the network discriminant of a given 'Address'.
+-- If the 'Address' is malformed or, not a shelley address, returns Nothing.
+--
+-- @since 2.0.0
+inspectNetworkDiscriminant
+    :: Address
+    -> Maybe (NetworkDiscriminant Shelley)
+inspectNetworkDiscriminant addr =
+    inspectShelleyAddress addr $>
+        let
+            bytes = unAddress addr
+            (fstByte, _) = first BS.head $ BS.splitAt 1 bytes
+            network  = fstByte .&. 0b00001111
+        in
+            NetworkTag $ fromIntegral network
 
 -- | 'NetworkDicriminant' for Cardano MainNet & Shelley
 --


### PR DESCRIPTION
  Before that, we would default to 'addr' prefix, even for testnet addresses.