### PR TITLE
Derivation of multisig keys

### DIFF
--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -23,7 +23,6 @@ module Cardano.Address.Derivation
     , GenMasterKey (..)
     , HardDerivation (..)
     , SoftDerivation (..)
-    , StakingDerivation (..)
 
     -- * Low-Level Cryptography Primitives
     -- ** XPrv
@@ -395,23 +394,6 @@ class HardDerivation key => SoftDerivation (key :: Depth -> * -> *) where
         -> Index 'Soft 'AddressK
         -> key 'AddressK XPub
 
--- | An interface for doing staking derivations from the account private key.
---
--- @since 2.0.0
-class StakingDerivation (key :: Depth -> * -> *) where
-    -- | Derive a staking key for a corresponding 'AccountK'. Note that wallet
-    -- software are by convention only using one staking key per account, and always
-    -- the first account (with index 0'). This will change when multi-account support
-    -- comes soon.
-    --
-    -- Deriving staking keys for something else than the initial account is not
-    -- recommended and can lead to incompatibility with existing wallet softwares
-    -- (Daedalus, Yoroi, Adalite...).
-    --
-    -- @since 2.0.0
-    deriveStakingPrivateKey
-        :: key 'AccountK XPrv
-        -> key 'StakingK XPrv
 
 -- | Abstract interface for constructing a /Master Key/.
 --

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -19,7 +18,6 @@ module Cardano.Address.Derivation
       Index
     , Depth (..)
     , DerivationType (..)
-    , AccountingStyle (..)
 
     -- * Abstractions
     , GenMasterKey (..)
@@ -75,8 +73,6 @@ import Data.Either.Extra
     ( eitherToMaybe )
 import Data.String
     ( fromString )
-import Data.Typeable
-    ( Typeable )
 import Data.Word
     ( Word32 )
 import Fmt
@@ -289,36 +285,6 @@ generateNew seed sndFactor =
 --
 -- @since 1.0.0
 data Depth = RootK | AccountK | AddressK | StakingK | MultisigK
-
--- | Marker for addresses type engaged. We want to handle three cases here.
--- The first two are pertinent to UTxO accounting
--- and the last one handles rewards from participation in staking.
--- (a) external chain is used for addresses that are part of the 'advertised'
---     targets of a given transaction
--- (b) internal change is for addresses used to handle the change of a
---     the transaction within a given wallet
--- (c) multisig keys
-data AccountingStyle
-    = UTxOExternal
-    | UTxOInternal
-    | Multisig
-    deriving (Generic, Typeable, Show, Eq, Ord, Bounded)
-
-instance NFData AccountingStyle
-
--- Not deriving 'Enum' because this could have a dramatic impact if we were
--- to assign the wrong index to the corresponding constructor (by swapping
--- around the constructor above for instance).
-instance Enum AccountingStyle where
-    toEnum = \case
-        0 -> UTxOExternal
-        1 -> UTxOInternal
-        3 -> Multisig
-        _ -> error "AccountingStyle.toEnum: bad argument"
-    fromEnum = \case
-        UTxOExternal -> 0
-        UTxOInternal -> 1
-        Multisig -> 3
 
 -- | A derivation index, with phantom-types to disambiguate derivation type.
 --

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -26,6 +26,7 @@ module Cardano.Address.Derivation
     , HardDerivation (..)
     , SoftDerivation (..)
     , StakingDerivation (..)
+    , MultisigDerivation (..)
 
     -- * Low-Level Cryptography Primitives
     -- ** XPrv
@@ -288,7 +289,7 @@ generateNew seed sndFactor =
 -- are no constructors for these.
 --
 -- @since 1.0.0
-data Depth = RootK | AccountK | AddressK | StakingK
+data Depth = RootK | AccountK | AddressK | StakingK | MultisigK
 
 -- | Marker for addresses type engaged. We want to handle three cases here.
 -- The first two are pertinent to UTxO accounting
@@ -431,7 +432,8 @@ class HardDerivation key => SoftDerivation (key :: Depth -> * -> *) where
 class StakingDerivation (key :: Depth -> * -> *) where
     -- | Derive a staking key for a corresponding 'AccountK'. Note that wallet
     -- software are by convention only using one staking key per account, and always
-    -- the first account (with index 0').
+    -- the first account (with index 0'). This will change when multi-account support
+    -- comes soon.
     --
     -- Deriving staking keys for something else than the initial account is not
     -- recommended and can lead to incompatibility with existing wallet softwares
@@ -442,6 +444,23 @@ class StakingDerivation (key :: Depth -> * -> *) where
         :: key 'AccountK XPrv
         -> key 'StakingK XPrv
 
+-- | An interface for doing multisig derivations from the account private key.
+--
+-- @since 3.0.0
+class MultisigDerivation (key :: Depth -> * -> *) where
+    -- | Derive a multisig key for a corresponding 'AccountK'. Note that wallet
+    -- software are by convention only using one multisig key per account, and always
+    -- the first account (with index 0'). This will change when multi-account support
+    -- comes soon.
+    --
+    -- Deriving multisig keys for something else than the initial account is not
+    -- recommended and can lead to incompatibility with existing wallet softwares
+    -- (Daedalus, Yoroi, Adalite...).
+    --
+    -- @since 3.0.0
+    deriveMultisigPrivateKey
+        :: key 'AccountK XPrv
+        -> key 'MultisigK XPrv
 
 -- | Abstract interface for constructing a /Master Key/.
 --

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -20,7 +20,6 @@ module Cardano.Address.Derivation
     , Depth (..)
     , DerivationType (..)
     , AccountingStyle (..)
-    , invariantAccountingStyle
 
     -- * Abstractions
     , GenMasterKey (..)
@@ -321,14 +320,6 @@ instance Enum AccountingStyle where
         UTxOInternal -> 1
         Multisig -> 3
 
-invariantAccountingStyle :: HasCallStack => AccountingStyle -> AccountingStyle
-invariantAccountingStyle role
-    | role == UTxOExternal || role ==  UTxOInternal = role
-    | otherwise = error
-      $ "accounting style "
-      ++ show role
-      ++ " was chosen, but expected either UTxOExternal or UTxOInternal"
-
 -- | A derivation index, with phantom-types to disambiguate derivation type.
 --
 -- @
@@ -434,7 +425,7 @@ class HardDerivation key => SoftDerivation (key :: Depth -> * -> *) where
     -- @since 1.0.0
     deriveAddressPublicKey
         :: key 'AccountK XPub
-        -> AccountingStyle
+        -> WithAccountStyle key
         -> Index 'Soft 'AddressK
         -> key 'AddressK XPub
 

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -26,7 +26,6 @@ module Cardano.Address.Derivation
     , HardDerivation (..)
     , SoftDerivation (..)
     , StakingDerivation (..)
-    , MultisigDerivation (..)
 
     -- * Low-Level Cryptography Primitives
     -- ** XPrv
@@ -298,9 +297,11 @@ data Depth = RootK | AccountK | AddressK | StakingK | MultisigK
 --     targets of a given transaction
 -- (b) internal change is for addresses used to handle the change of a
 --     the transaction within a given wallet
+-- (c) multisig keys
 data AccountingStyle
     = UTxOExternal
     | UTxOInternal
+    | Multisig
     deriving (Generic, Typeable, Show, Eq, Ord, Bounded)
 
 instance NFData AccountingStyle
@@ -312,10 +313,12 @@ instance Enum AccountingStyle where
     toEnum = \case
         0 -> UTxOExternal
         1 -> UTxOInternal
+        3 -> Multisig
         _ -> error "AccountingStyle.toEnum: bad argument"
     fromEnum = \case
         UTxOExternal -> 0
         UTxOInternal -> 1
+        Multisig -> 3
 
 -- | A derivation index, with phantom-types to disambiguate derivation type.
 --
@@ -443,24 +446,6 @@ class StakingDerivation (key :: Depth -> * -> *) where
     deriveStakingPrivateKey
         :: key 'AccountK XPrv
         -> key 'StakingK XPrv
-
--- | An interface for doing multisig derivations from the account private key.
---
--- @since 3.0.0
-class MultisigDerivation (key :: Depth -> * -> *) where
-    -- | Derive a multisig key for a corresponding 'AccountK'. Note that wallet
-    -- software are by convention only using one multisig key per account, and always
-    -- the first account (with index 0'). This will change when multi-account support
-    -- comes soon.
-    --
-    -- Deriving multisig keys for something else than the initial account is not
-    -- recommended and can lead to incompatibility with existing wallet softwares
-    -- (Daedalus, Yoroi, Adalite...).
-    --
-    -- @since 3.0.0
-    deriveMultisigPrivateKey
-        :: key 'AccountK XPrv
-        -> key 'MultisigK XPrv
 
 -- | Abstract interface for constructing a /Master Key/.
 --

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -20,6 +20,7 @@ module Cardano.Address.Derivation
     , Depth (..)
     , DerivationType (..)
     , AccountingStyle (..)
+    , invariantAccountingStyle
 
     -- * Abstractions
     , GenMasterKey (..)
@@ -319,6 +320,14 @@ instance Enum AccountingStyle where
         UTxOExternal -> 0
         UTxOInternal -> 1
         Multisig -> 3
+
+invariantAccountingStyle :: HasCallStack => AccountingStyle -> AccountingStyle
+invariantAccountingStyle role
+    | role == UTxOExternal || role ==  UTxOInternal = role
+    | otherwise = error
+      $ "accounting style "
+      ++ show role
+      ++ " was chosen, but expected either UTxOExternal or UTxOInternal"
 
 -- | A derivation index, with phantom-types to disambiguate derivation type.
 --

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -356,7 +356,7 @@ data DerivationType = Hardened | Soft | WholeDomain
 class HardDerivation (key :: Depth -> * -> *) where
     type AccountIndexDerivationType key :: DerivationType
     type AddressIndexDerivationType key :: DerivationType
-    type WithAccountStyle key :: *
+    type WithRole key :: *
 
     -- | Derives account private key from the given root private key, using
     -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
@@ -375,7 +375,7 @@ class HardDerivation (key :: Depth -> * -> *) where
     -- @since 1.0.0
     deriveAddressPrivateKey
         :: key 'AccountK XPrv
-        -> WithAccountStyle key
+        -> WithRole key
         -> Index (AddressIndexDerivationType key) 'AddressK
         -> key 'AddressK XPrv
 
@@ -390,7 +390,7 @@ class HardDerivation key => SoftDerivation (key :: Depth -> * -> *) where
     -- @since 1.0.0
     deriveAddressPublicKey
         :: key 'AccountK XPub
-        -> WithAccountStyle key
+        -> WithRole key
         -> Index 'Soft 'AddressK
         -> key 'AddressK XPub
 

--- a/core/lib/Cardano/Address/Style/Byron.hs
+++ b/core/lib/Cardano/Address/Style/Byron.hs
@@ -220,7 +220,7 @@ instance Internal.GenMasterKey Byron where
 instance Internal.HardDerivation Byron where
     type AddressIndexDerivationType Byron = 'WholeDomain
     type AccountIndexDerivationType Byron = 'WholeDomain
-    type WithAccountStyle Byron = ()
+    type WithRole Byron = ()
 
     deriveAccountPrivateKey rootXPrv accIx = Byron
         { getKey = deriveXPrv DerivationScheme1 (getKey rootXPrv) accIx

--- a/core/lib/Cardano/Address/Style/Icarus.hs
+++ b/core/lib/Cardano/Address/Style/Icarus.hs
@@ -202,7 +202,7 @@ instance Enum Role where
 -- > let acctK = deriveAccountPrivateKey rootK accIx
 -- >
 -- > let addIx = toEnum 0x00000014
--- > let addrK = deriveAddressPrivateKey acctK External addIx
+-- > let addrK = deriveAddressPrivateKey acctK UTxOExternal addIx
 
 instance Internal.GenMasterKey Icarus where
     type SecondFactor Icarus = ScrubbedBytes

--- a/core/lib/Cardano/Address/Style/Icarus.hs
+++ b/core/lib/Cardano/Address/Style/Icarus.hs
@@ -219,7 +219,7 @@ instance Internal.GenMasterKey Icarus where
 instance Internal.HardDerivation Icarus where
     type AccountIndexDerivationType Icarus = 'Hardened
     type AddressIndexDerivationType Icarus = 'Soft
-    type WithAccountStyle Icarus = Role
+    type WithRole Icarus = Role
 
     deriveAccountPrivateKey (Icarus rootXPrv) accIx =
         let
@@ -238,9 +238,9 @@ instance Internal.HardDerivation Icarus where
 
     deriveAddressPrivateKey (Icarus accXPrv) role addrIx =
         let
-            changeCode = toEnum @(Index 'Soft _) $ fromEnum role
+            roleCode = toEnum @(Index 'Soft _) $ fromEnum role
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
-                deriveXPrv DerivationScheme2 accXPrv changeCode
+                deriveXPrv DerivationScheme2 accXPrv roleCode
             addrXPrv = -- lvl5 derivation; soft derivation of address index
                 deriveXPrv DerivationScheme2 changeXPrv addrIx
         in
@@ -249,9 +249,9 @@ instance Internal.HardDerivation Icarus where
 instance Internal.SoftDerivation Icarus where
     deriveAddressPublicKey (Icarus accXPub) role addrIx =
         fromMaybe errWrongIndex $ do
-            let changeCode = toEnum @(Index 'Soft _) $ fromEnum role
+            let roleCode = toEnum @(Index 'Soft _) $ fromEnum role
             changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
-                deriveXPub DerivationScheme2 accXPub changeCode
+                deriveXPub DerivationScheme2 accXPub roleCode
             addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain
                 deriveXPub DerivationScheme2 changeXPub addrIx
             return $ Icarus addrXPub

--- a/core/lib/Cardano/Address/Style/Icarus.hs
+++ b/core/lib/Cardano/Address/Style/Icarus.hs
@@ -71,6 +71,7 @@ import Cardano.Address.Derivation
     , deriveXPrv
     , deriveXPub
     , generateNew
+    , invariantAccountingStyle
     , xprvFromBytes
     )
 import Cardano.Address.Errors
@@ -218,8 +219,8 @@ instance Internal.HardDerivation Icarus where
 
     deriveAddressPrivateKey (Icarus accXPrv) accountingStyle addrIx =
         let
-            changeCode =
-                toEnum @(Index 'Soft _) $ fromEnum accountingStyle
+            changeCode = toEnum @(Index 'Soft _) $
+                fromEnum (invariantAccountingStyle accountingStyle)
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
                 deriveXPrv DerivationScheme2 accXPrv changeCode
             addrXPrv = -- lvl5 derivation; soft derivation of address index
@@ -230,7 +231,8 @@ instance Internal.HardDerivation Icarus where
 instance Internal.SoftDerivation Icarus where
     deriveAddressPublicKey (Icarus accXPub) accountingStyle addrIx =
         fromMaybe errWrongIndex $ do
-            let changeCode = toEnum @(Index 'Soft _) $ fromEnum accountingStyle
+            let changeCode = toEnum @(Index 'Soft _) $
+                    fromEnum (invariantAccountingStyle accountingStyle)
             changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
                 deriveXPub DerivationScheme2 accXPub changeCode
             addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain

--- a/core/lib/Cardano/Address/Style/Jormungandr.hs
+++ b/core/lib/Cardano/Address/Style/Jormungandr.hs
@@ -264,12 +264,6 @@ instance Internal.SoftDerivation Jormungandr where
             \either a programmer error, or, we may have reached the maximum \
             \number of addresses for a given wallet."
 
-instance Internal.StakingDerivation Jormungandr where
-    deriveStakingPrivateKey accXPrv =
-        let (Jormungandr stakeXPrv) =
-                deriveAddressPrivateKey accXPrv Stake (minBound @(Index 'Soft _))
-        in Jormungandr stakeXPrv
-
 -- | Generate a root key from a corresponding mnemonic.
 --
 -- @since 2.0.0
@@ -342,8 +336,10 @@ deriveAddressPublicKey =
 deriveStakingPrivateKey
     :: Jormungandr 'AccountK XPrv
     -> Jormungandr 'StakingK XPrv
-deriveStakingPrivateKey =
-    Internal.deriveStakingPrivateKey
+deriveStakingPrivateKey accXPrv =
+    let (Jormungandr stakeXPrv) =
+            deriveAddressPrivateKey accXPrv Stake (minBound @(Index 'Soft _))
+    in Jormungandr stakeXPrv
 
 --
 -- Addresses

--- a/core/lib/Cardano/Address/Style/Jormungandr.hs
+++ b/core/lib/Cardano/Address/Style/Jormungandr.hs
@@ -269,15 +269,7 @@ instance Internal.StakingDerivation Jormungandr where
         let (Jormungandr stakeXPrv) =
                 deriveAddressPrivateKey accXPrv Stake (minBound @(Index 'Soft _))
         in Jormungandr stakeXPrv
-        {--
-        let
-            changeXPrv = -- lvl4 derivation; soft derivation of change chain
-                deriveXPrv DerivationScheme2 accXPrv (toEnum @(Index 'Soft _) 2)
-            stakeXPrv = -- lvl5 derivation; soft derivation of address index
-                deriveXPrv DerivationScheme2 changeXPrv (minBound @(Index 'Soft _))
-        in
-            Jormungandr stakeXPrv
---}
+
 -- | Generate a root key from a corresponding mnemonic.
 --
 -- @since 2.0.0

--- a/core/lib/Cardano/Address/Style/Jormungandr.hs
+++ b/core/lib/Cardano/Address/Style/Jormungandr.hs
@@ -74,7 +74,6 @@ import Cardano.Address.Derivation
     , deriveXPrv
     , deriveXPub
     , generateNew
-    , invariantAccountingStyle
     , xpubPublicKey
     )
 import Cardano.Address.Errors
@@ -219,7 +218,7 @@ instance Internal.HardDerivation Jormungandr where
     deriveAddressPrivateKey (Jormungandr accXPrv) accountingStyle addrIx =
         let
             changeCode = toEnum @(Index 'Soft _) $
-                fromEnum (invariantAccountingStyle accountingStyle)
+                fromEnum accountingStyle
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
                 deriveXPrv DerivationScheme2 accXPrv changeCode
             addrXPrv = -- lvl5 derivation; soft derivation of address index
@@ -231,7 +230,7 @@ instance Internal.SoftDerivation Jormungandr where
     deriveAddressPublicKey (Jormungandr accXPub) accountingStyle addrIx =
         fromMaybe errWrongIndex $ do
             let changeCode = toEnum @(Index 'Soft _) $
-                    fromEnum (invariantAccountingStyle accountingStyle)
+                    fromEnum accountingStyle
             changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
                 deriveXPub DerivationScheme2 accXPub changeCode
             addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain

--- a/core/lib/Cardano/Address/Style/Jormungandr.hs
+++ b/core/lib/Cardano/Address/Style/Jormungandr.hs
@@ -74,6 +74,7 @@ import Cardano.Address.Derivation
     , deriveXPrv
     , deriveXPub
     , generateNew
+    , invariantAccountingStyle
     , xpubPublicKey
     )
 import Cardano.Address.Errors
@@ -217,8 +218,8 @@ instance Internal.HardDerivation Jormungandr where
 
     deriveAddressPrivateKey (Jormungandr accXPrv) accountingStyle addrIx =
         let
-            changeCode =
-                toEnum @(Index 'Soft _) $ fromEnum accountingStyle
+            changeCode = toEnum @(Index 'Soft _) $
+                fromEnum (invariantAccountingStyle accountingStyle)
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
                 deriveXPrv DerivationScheme2 accXPrv changeCode
             addrXPrv = -- lvl5 derivation; soft derivation of address index
@@ -229,7 +230,8 @@ instance Internal.HardDerivation Jormungandr where
 instance Internal.SoftDerivation Jormungandr where
     deriveAddressPublicKey (Jormungandr accXPub) accountingStyle addrIx =
         fromMaybe errWrongIndex $ do
-            let changeCode = toEnum @(Index 'Soft _) $ fromEnum accountingStyle
+            let changeCode = toEnum @(Index 'Soft _) $
+                    fromEnum (invariantAccountingStyle accountingStyle)
             changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
                 deriveXPub DerivationScheme2 accXPub changeCode
             addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain

--- a/core/lib/Cardano/Address/Style/Jormungandr.hs
+++ b/core/lib/Cardano/Address/Style/Jormungandr.hs
@@ -221,7 +221,7 @@ instance Internal.GenMasterKey Jormungandr where
 instance Internal.HardDerivation Jormungandr where
     type AccountIndexDerivationType Jormungandr = 'Hardened
     type AddressIndexDerivationType Jormungandr = 'Soft
-    type WithAccountStyle Jormungandr = Role
+    type WithRole Jormungandr = Role
 
     deriveAccountPrivateKey (Jormungandr rootXPrv) accIx =
         let
@@ -240,9 +240,9 @@ instance Internal.HardDerivation Jormungandr where
 
     deriveAddressPrivateKey (Jormungandr accXPrv) role addrIx =
         let
-            changeCode = toEnum @(Index 'Soft _) $ fromEnum role
+            roleCode = toEnum @(Index 'Soft _) $ fromEnum role
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
-                deriveXPrv DerivationScheme2 accXPrv changeCode
+                deriveXPrv DerivationScheme2 accXPrv roleCode
             addrXPrv = -- lvl5 derivation; soft derivation of address index
                 deriveXPrv DerivationScheme2 changeXPrv addrIx
         in
@@ -251,9 +251,9 @@ instance Internal.HardDerivation Jormungandr where
 instance Internal.SoftDerivation Jormungandr where
     deriveAddressPublicKey (Jormungandr accXPub) role addrIx =
         fromMaybe errWrongIndex $ do
-            let changeCode = toEnum @(Index 'Soft _) $ fromEnum role
+            let roleCode = toEnum @(Index 'Soft _) $ fromEnum role
             changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
-                deriveXPub DerivationScheme2 accXPub changeCode
+                deriveXPub DerivationScheme2 accXPub roleCode
             addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain
                 deriveXPub DerivationScheme2 changeXPub addrIx
             return $ Jormungandr addrXPub

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -295,12 +295,6 @@ instance Internal.SoftDerivation Shelley where
             \either a programmer error, or, we may have reached the maximum \
             \number of addresses for a given wallet."
 
-instance Internal.StakingDerivation Shelley where
-    deriveStakingPrivateKey accXPrv =
-        let (Shelley stakeXPrv) =
-                deriveAddressPrivateKey accXPrv Stake (minBound @(Index 'Soft _))
-        in Shelley stakeXPrv
-
 -- | Generate a root key from a corresponding mnemonic.
 --
 -- @since 2.0.0
@@ -373,8 +367,10 @@ deriveAddressPublicKey =
 deriveStakingPrivateKey
     :: Shelley 'AccountK XPrv
     -> Shelley 'StakingK XPrv
-deriveStakingPrivateKey =
-    Internal.deriveStakingPrivateKey
+deriveStakingPrivateKey accXPrv =
+    let (Shelley stakeXPrv) =
+            deriveAddressPrivateKey accXPrv Stake (minBound @(Index 'Soft _))
+    in Shelley stakeXPrv
 
 
 -- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -251,7 +251,7 @@ instance Internal.GenMasterKey Shelley where
 instance Internal.HardDerivation Shelley where
     type AccountIndexDerivationType Shelley = 'Hardened
     type AddressIndexDerivationType Shelley = 'Soft
-    type WithAccountStyle Shelley = Role
+    type WithRole Shelley = Role
 
     deriveAccountPrivateKey (Shelley rootXPrv) accIx =
         let
@@ -270,10 +270,9 @@ instance Internal.HardDerivation Shelley where
 
     deriveAddressPrivateKey (Shelley accXPrv) role addrIx =
         let
-            changeCode =
-                toEnum @(Index 'Soft _) $ fromEnum role
+            roleCode = toEnum @(Index 'Soft _) $ fromEnum role
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
-                deriveXPrv DerivationScheme2 accXPrv changeCode
+                deriveXPrv DerivationScheme2 accXPrv roleCode
             addrXPrv = -- lvl5 derivation; soft derivation of address index
                 deriveXPrv DerivationScheme2 changeXPrv addrIx
         in
@@ -282,9 +281,9 @@ instance Internal.HardDerivation Shelley where
 instance Internal.SoftDerivation Shelley where
     deriveAddressPublicKey (Shelley accXPub) role addrIx =
         fromMaybe errWrongIndex $ do
-            let changeCode = toEnum @(Index 'Soft _) $ fromEnum role
+            let roleCode = toEnum @(Index 'Soft _) $ fromEnum role
             changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
-                deriveXPub DerivationScheme2 accXPub changeCode
+                deriveXPub DerivationScheme2 accXPub roleCode
             addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain
                 deriveXPub DerivationScheme2 changeXPub addrIx
             return $ Shelley addrXPub

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -296,15 +296,10 @@ instance Internal.SoftDerivation Shelley where
             \number of addresses for a given wallet."
 
 instance Internal.StakingDerivation Shelley where
-    deriveStakingPrivateKey (Shelley accXPrv) =
-        let
-            changeXPrv = -- lvl4 derivation; soft derivation of change chain
-                deriveXPrv DerivationScheme2 accXPrv (toEnum @(Index 'Soft _) 2)
-            stakeXPrv = -- lvl5 derivation; soft derivation of address index
-                deriveXPrv DerivationScheme2 changeXPrv (minBound @(Index 'Soft _))
-        in
-            Shelley stakeXPrv
-
+    deriveStakingPrivateKey accXPrv =
+        let (Shelley stakeXPrv) =
+                deriveAddressPrivateKey accXPrv Stake (minBound @(Index 'Soft _))
+        in Shelley stakeXPrv
 
 -- | Generate a root key from a corresponding mnemonic.
 --

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -32,6 +32,8 @@ module Cardano.Address.Style.Shelley
     , deriveAddressPrivateKey
     , deriveStakingPrivateKey
     , deriveAddressPublicKey
+    , deriveMultisigPrivateKey
+    , deriveMultisigPublicKey
 
       -- * Addresses
       -- $addresses
@@ -351,6 +353,32 @@ deriveStakingPrivateKey
 deriveStakingPrivateKey =
     Internal.deriveStakingPrivateKey
 
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.
+--
+-- | Derives a multisig private key from the given account private key.
+--
+-- @since 3.0.0
+deriveMultisigPrivateKey
+    :: Shelley 'AccountK XPrv
+    -> Index 'Soft 'AddressK
+    -> Shelley 'MultisigK XPrv
+deriveMultisigPrivateKey accPrv addrIx =
+    let (Shelley xprv) = Internal.deriveAddressPrivateKey accPrv Internal.Multisig addrIx
+    in Shelley xprv
+
+-- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock
+--
+-- | Derives a multisig public key from the given account public key.
+--
+-- @since 3.0.0
+deriveMultisigPublicKey
+    :: Shelley 'AccountK XPub
+    -> Index 'Soft 'AddressK
+    -> Shelley 'MultisigK XPub
+deriveMultisigPublicKey accPub addrIx =
+    let (Shelley xprv) = Internal.deriveAddressPublicKey accPub Internal.Multisig addrIx
+    in Shelley xprv
 
 --
 -- Addresses

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -198,8 +198,6 @@ instance (NFData key) => NFData (Shelley depth key)
 --
 -- Let's consider the following 3rd, 4th and 5th derivation paths @0'\/0\/14@
 --
--- > import Cardano.Address.Derivation ( AccountingStyle(..) )
--- >
 -- > let accIx = toEnum 0x80000000
 -- > let acctK = deriveAccountPrivateKey rootK accIx
 -- >
@@ -240,10 +238,10 @@ instance Internal.HardDerivation Shelley where
         in
             Shelley acctXPrv
 
-    deriveAddressPrivateKey (Shelley accXPrv) accountingStyle addrIx =
+    deriveAddressPrivateKey (Shelley accXPrv) role addrIx =
         let
             changeCode =
-                toEnum @(Index 'Soft _) $ fromEnum accountingStyle
+                toEnum @(Index 'Soft _) $ fromEnum role
             changeXPrv = -- lvl4 derivation; soft derivation of change chain
                 deriveXPrv DerivationScheme2 accXPrv changeCode
             addrXPrv = -- lvl5 derivation; soft derivation of address index
@@ -252,9 +250,9 @@ instance Internal.HardDerivation Shelley where
             Shelley addrXPrv
 
 instance Internal.SoftDerivation Shelley where
-    deriveAddressPublicKey (Shelley accXPub) accountingStyle addrIx =
+    deriveAddressPublicKey (Shelley accXPub) role addrIx =
         fromMaybe errWrongIndex $ do
-            let changeCode = toEnum @(Index 'Soft _) $ fromEnum accountingStyle
+            let changeCode = toEnum @(Index 'Soft _) $ fromEnum role
             changeXPub <- -- lvl4 derivation in bip44 is derivation of change chain
                 deriveXPub DerivationScheme2 accXPub changeCode
             addrXPub <- -- lvl5 derivation in bip44 is derivation of address chain
@@ -276,6 +274,7 @@ instance Internal.StakingDerivation Shelley where
                 deriveXPrv DerivationScheme2 changeXPrv (minBound @(Index 'Soft _))
         in
             Shelley stakeXPrv
+
 
 -- | Generate a root key from a corresponding mnemonic.
 --
@@ -352,6 +351,7 @@ deriveStakingPrivateKey
 deriveStakingPrivateKey =
     Internal.deriveStakingPrivateKey
 
+
 --
 -- Addresses
 --
@@ -359,7 +359,7 @@ deriveStakingPrivateKey =
 -- === Generating a 'PaymentAddress'
 --
 -- > import Cardano.Address ( bech32 )
--- > import Cardano.Address.Derivation ( AccountingStyle(..), toXPub )
+-- > import Cardano.Address.Derivation ( toXPub )
 -- >
 -- > let (Right tag) = mkNetworkDiscriminant 1
 -- > bech32 $ paymentAddress tag (toXPub <$> addrK)

--- a/core/test/Cardano/Address/Style/IcarusSpec.hs
+++ b/core/test/Cardano/Address/Style/IcarusSpec.hs
@@ -48,7 +48,7 @@ import Test.Arbitrary
 import Test.Hspec
     ( Spec, describe, it, shouldBe )
 import Test.QuickCheck
-    ( Property, property, (===) )
+    ( Property, property, (===), (==>) )
 
 import qualified Data.Text as T
 
@@ -170,7 +170,7 @@ prop_publicChildKeyDerivation
     -> Index 'Soft 'AddressK
     -> Property
 prop_publicChildKeyDerivation mw cc ix =
-    addrXPub1 === addrXPub2
+    (cc == UTxOExternal || cc ==  UTxOInternal) ==> addrXPub1 === addrXPub2
   where
     rootXPrv = genMasterKeyFromMnemonic mw mempty :: Icarus 'RootK XPrv
     accXPrv  = deriveAccountPrivateKey rootXPrv minBound

--- a/core/test/Cardano/Address/Style/IcarusSpec.hs
+++ b/core/test/Cardano/Address/Style/IcarusSpec.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Cardano.Address.Style.IcarusSpec
     ( spec
     ) where
@@ -18,8 +20,7 @@ import Prelude
 import Cardano.Address
     ( PaymentAddress (..), base58 )
 import Cardano.Address.Derivation
-    ( AccountingStyle (..)
-    , Depth (..)
+    ( Depth (..)
     , DerivationType (..)
     , GenMasterKey (..)
     , HardDerivation (..)
@@ -29,7 +30,11 @@ import Cardano.Address.Derivation
     , toXPub
     )
 import Cardano.Address.Style.Icarus
-    ( Icarus (..), icarusMainnet, unsafeGenerateKeyFromHardwareLedger )
+    ( Icarus (..)
+    , Role (..)
+    , icarusMainnet
+    , unsafeGenerateKeyFromHardwareLedger
+    )
 import Cardano.Mnemonic
     ( ConsistentEntropy
     , EntropySize
@@ -48,7 +53,7 @@ import Test.Arbitrary
 import Test.Hspec
     ( Spec, describe, it, shouldBe )
 import Test.QuickCheck
-    ( Property, property, (===), (==>) )
+    ( Arbitrary (..), Property, arbitraryBoundedEnum, property, (===) )
 
 import qualified Data.Text as T
 
@@ -166,18 +171,18 @@ spec = do
 -- For details see <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key bip-0039>
 prop_publicChildKeyDerivation
     :: SomeMnemonic
-    -> AccountingStyle
+    -> Role
     -> Index 'Soft 'AddressK
     -> Property
-prop_publicChildKeyDerivation mw cc ix =
-    (cc == UTxOExternal || cc ==  UTxOInternal) ==> addrXPub1 === addrXPub2
+prop_publicChildKeyDerivation mw role ix =
+    addrXPub1 === addrXPub2
   where
     rootXPrv = genMasterKeyFromMnemonic mw mempty :: Icarus 'RootK XPrv
     accXPrv  = deriveAccountPrivateKey rootXPrv minBound
     -- N(CKDpriv((kpar, cpar), i))
-    addrXPub1 = toXPub <$> deriveAddressPrivateKey accXPrv cc ix
+    addrXPub1 = toXPub <$> deriveAddressPrivateKey accXPrv role ix
     -- CKDpub(N(kpar, cpar), i)
-    addrXPub2 = deriveAddressPublicKey (toXPub <$> accXPrv) cc ix
+    addrXPub2 = deriveAddressPublicKey (toXPub <$> accXPrv) role ix
 
 prop_accountKeyDerivation
     :: SomeMnemonic
@@ -196,7 +201,7 @@ prop_accountKeyDerivation mw ix =
 data GoldenAddressGeneration = GoldenAddressGeneration
     { goldSeed :: SomeMnemonic
     , goldAcctIx :: Index 'Hardened 'AccountK
-    , goldAcctStyle :: AccountingStyle
+    , goldAcctStyle :: Role
     , goldAddrIx :: Index 'Soft 'AddressK
     , goldAddr :: Text
     }
@@ -262,3 +267,7 @@ goldenHardwareLedger sentence addrs =
     title = T.unpack
         $ T.unwords
         $ take 3 sentence ++ [ "..." ] ++ drop (length sentence - 3) sentence
+
+instance Arbitrary Role where
+    shrink _ = []
+    arbitrary = arbitraryBoundedEnum

--- a/core/test/Cardano/Address/Style/JormungandrSpec.hs
+++ b/core/test/Cardano/Address/Style/JormungandrSpec.hs
@@ -74,7 +74,7 @@ prop_publicChildKeyDerivation
     -> Index 'Soft 'AddressK
     -> Property
 prop_publicChildKeyDerivation (mw, (SndFactor sndFactor)) cc ix =
-    addrXPub1 === addrXPub2
+    (cc == UTxOExternal || cc ==  UTxOInternal) ==> addrXPub1 === addrXPub2
   where
     rootXPrv = genMasterKeyFromMnemonic mw sndFactor :: Jormungandr 'RootK XPrv
     accXPrv  = deriveAccountPrivateKey rootXPrv minBound

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -36,7 +36,6 @@ import Cardano.Address.Derivation
     , HardDerivation (..)
     , Index
     , SoftDerivation (..)
-    , StakingDerivation (..)
     , XPrv
     , XPub
     , toXPub
@@ -45,7 +44,12 @@ import Cardano.Address.Derivation
     , xpubToBytes
     )
 import Cardano.Address.Style.Shelley
-    ( Role (..), Shelley (..), liftXPub, mkNetworkDiscriminant )
+    ( Role (..)
+    , Shelley (..)
+    , deriveStakingPrivateKey
+    , liftXPub
+    , mkNetworkDiscriminant
+    )
 import Cardano.Mnemonic
     ( SomeMnemonic, mkSomeMnemonic )
 import Codec.Binary.Encoding

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -27,7 +27,6 @@ import Cardano.Address.Derivation
     , GenMasterKey (..)
     , HardDerivation (..)
     , Index
-    , StakingDerivation (..)
     , XPrv
     , XPub
     , generate
@@ -78,9 +77,12 @@ import Numeric.Natural
 import Test.QuickCheck
     ( Arbitrary (..), Gen, arbitraryBoundedEnum, choose, oneof, vector )
 
+import qualified Cardano.Address.Style.Jormungandr as Jormungandr
+import qualified Cardano.Address.Style.Shelley as Shelley
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
+
 --
 -- Arbitrary Instances
 --
@@ -196,7 +198,7 @@ instance Arbitrary (Shelley 'StakingK XPub) where
         bytes <- BA.convert . BS.pack <$> (choose (0, 32) >>= vector)
         let rootK = genMasterKeyFromMnemonic mw bytes
         acctK <- deriveAccountPrivateKey rootK <$> arbitrary
-        let stakingK = deriveStakingPrivateKey acctK
+        let stakingK = Shelley.deriveStakingPrivateKey acctK
         pure $ toXPub <$> stakingK
 
 instance Arbitrary (Jormungandr 'StakingK XPub) where
@@ -206,7 +208,7 @@ instance Arbitrary (Jormungandr 'StakingK XPub) where
         bytes <- BA.convert . BS.pack <$> (choose (0, 32) >>= vector)
         let rootK = genMasterKeyFromMnemonic mw bytes
         acctK <- deriveAccountPrivateKey rootK <$> arbitrary
-        let stakingK = deriveStakingPrivateKey acctK
+        let stakingK = Jormungandr.deriveStakingPrivateKey acctK
         pure $ toXPub <$> stakingK
 
 instance {-# OVERLAPS #-} Arbitrary (AddressDiscrimination, NetworkTag) where

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -189,7 +189,7 @@ instance Arbitrary (Jormungandr 'AddressK XPub) where
         bytes <- BA.convert . BS.pack <$> (choose (0, 32) >>= vector)
         let rootK = genMasterKeyFromMnemonic mw bytes
         acctK <- deriveAccountPrivateKey rootK <$> arbitrary
-        let roleGen =  oneof [pure UTxOExternal, pure UTxOInternal]
+        let roleGen = arbitraryBoundedEnum
         addrK <- deriveAddressPrivateKey acctK <$> roleGen <*> arbitrary
         pure $ toXPub <$> addrK
 

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -22,7 +22,7 @@ import Prelude
 import Cardano.Address
     ( AddressDiscrimination (..), ChainPointer (..), NetworkTag (..) )
 import Cardano.Address.Derivation
-    ( AccountingStyle
+    ( AccountingStyle (..)
     , Depth (..)
     , DerivationType (..)
     , GenMasterKey (..)
@@ -151,7 +151,7 @@ instance Arbitrary XPub where
 
 instance Arbitrary AccountingStyle where
     shrink _ = []
-    arbitrary = arbitraryBoundedEnum
+    arbitrary = oneof [pure UTxOExternal, pure UTxOInternal, pure Multisig]
 
 instance Arbitrary (Byron 'AddressK XPub) where
     shrink _ = []
@@ -169,7 +169,8 @@ instance Arbitrary (Icarus 'AddressK XPub) where
         bytes <- BA.convert . BS.pack <$> (choose (0, 32) >>= vector)
         let rootK = genMasterKeyFromMnemonic mw bytes
         acctK <- deriveAccountPrivateKey rootK <$> arbitrary
-        addrK <- deriveAddressPrivateKey acctK <$> arbitrary <*> arbitrary
+        let roleGen =  oneof [pure UTxOExternal, pure UTxOInternal]
+        addrK <- deriveAddressPrivateKey acctK <$> roleGen <*> arbitrary
         pure $ toXPub <$> addrK
 
 instance Arbitrary (Shelley 'AddressK XPub) where
@@ -189,7 +190,8 @@ instance Arbitrary (Jormungandr 'AddressK XPub) where
         bytes <- BA.convert . BS.pack <$> (choose (0, 32) >>= vector)
         let rootK = genMasterKeyFromMnemonic mw bytes
         acctK <- deriveAccountPrivateKey rootK <$> arbitrary
-        addrK <- deriveAddressPrivateKey acctK <$> arbitrary <*> arbitrary
+        let roleGen =  oneof [pure UTxOExternal, pure UTxOInternal]
+        addrK <- deriveAddressPrivateKey acctK <$> roleGen <*> arbitrary
         pure $ toXPub <$> addrK
 
 instance Arbitrary (Shelley 'StakingK XPub) where

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -82,7 +82,6 @@ import Test.QuickCheck
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
-
 --
 -- Arbitrary Instances
 --
@@ -169,7 +168,7 @@ instance Arbitrary (Icarus 'AddressK XPub) where
         bytes <- BA.convert . BS.pack <$> (choose (0, 32) >>= vector)
         let rootK = genMasterKeyFromMnemonic mw bytes
         acctK <- deriveAccountPrivateKey rootK <$> arbitrary
-        let roleGen =  oneof [pure UTxOExternal, pure UTxOInternal]
+        let roleGen =  arbitraryBoundedEnum
         addrK <- deriveAddressPrivateKey acctK <$> roleGen <*> arbitrary
         pure $ toXPub <$> addrK
 

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -22,8 +22,7 @@ import Prelude
 import Cardano.Address
     ( AddressDiscrimination (..), ChainPointer (..), NetworkTag (..) )
 import Cardano.Address.Derivation
-    ( AccountingStyle (..)
-    , Depth (..)
+    ( Depth (..)
     , DerivationType (..)
     , GenMasterKey (..)
     , HardDerivation (..)
@@ -148,10 +147,6 @@ instance Arbitrary XPub where
     arbitrary =
         toXPub <$> arbitrary
 
-instance Arbitrary AccountingStyle where
-    shrink _ = []
-    arbitrary = oneof [pure UTxOExternal, pure UTxOInternal, pure Multisig]
-
 instance Arbitrary (Byron 'AddressK XPub) where
     shrink _ = []
     arbitrary = do
@@ -179,7 +174,8 @@ instance Arbitrary (Shelley 'AddressK XPub) where
         bytes <- BA.convert . BS.pack <$> (choose (0, 32) >>= vector)
         let rootK = genMasterKeyFromMnemonic mw bytes
         acctK <- deriveAccountPrivateKey rootK <$> arbitrary
-        addrK <- deriveAddressPrivateKey acctK <$> arbitrary <*> arbitrary
+        let roleGen = arbitraryBoundedEnum
+        addrK <- deriveAddressPrivateKey acctK <$> roleGen <*> arbitrary
         pure $ toXPub <$> addrK
 
 instance Arbitrary (Jormungandr 'AddressK XPub) where


### PR DESCRIPTION
Issue number #72 

I renamed `AccountingStyle` to `Role` and extended it by `Stake` (for Jormungandr), and also by `Multisig` (for Shelley), also extended `Depth` by `MultisigK` and used those to implement `deriveMultisigPrivateKey` and `deriveMultisigPublicKey`. The existing test in ShelleySpec checks : 
```
N(CKDpriv((kpar, cpar), i)) === CKDpub(N(kpar, cpar), i)
``` 
Moreover, I introduced separate Role for Icarus, Shelley and Jormungandr and adjusted the corresponding code accordingly.
Removed `StakingDerivation` interface