### PR TITLE
allow '--network-tag' to also accept pre-defined keywords: mainnet, staging, testnet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ xpub16y4vhpyuj2t84gh2qfe3ydng3wc37yqzxev6gce380fvvg47ye8um3dm3wn5a64gt7l0fh5j6sj
 
   $ cat addr.prv \
   | cardano-address key public \
-  | cardano-address address payment --network-tag 0
+  | cardano-address address payment --network-tag testnet
 
   addr_test1vqrlltfahghjxl5sy5h5mvfrrlt6me5fqphhwjqvj5jd88cccqcek
 ```
@@ -101,7 +101,7 @@ xpub16y4vhpyuj2t84gh2qfe3ydng3wc37yqzxev6gce380fvvg47ye8um3dm3wn5a64gt7l0fh5j6sj
 
   $ cat addr.prv \
   | cardano-address key public \
-  | cardano-address address payment --network-tag 0 \
+  | cardano-address address payment --network-tag testnet \
   | cardano-address address delegation $(cat stake.prv | cardano-address key public)
   addr1vrcmygdgp7v3mhz78v8kdsfru0y9wysnr9pgvvgmdqx2w0qrg8swg...
 ```

--- a/command-line/lib/Command/Address/Bootstrap.hs
+++ b/command-line/lib/Command/Address/Bootstrap.hs
@@ -69,7 +69,7 @@ mod liftCmd = command "bootstrap" $
             , indent 4 $ bold $ string $ "| "<>progName<>" key child 14H/42H > addr.prv"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" address bootstrap --root $(cat root.prv | "<>progName<>" key public) \\"
-            , indent 8 $ bold $ string "--network-tag 764824073 14H/42H"
+            , indent 8 $ bold $ string "--network-tag testnet 14H/42H"
             , indent 2 $ string "DdzFFzCqrht2KG1vWt5WGhVC9Ezyu32RgB5M2DocdZ6BQU6zj69LSqksDmdM..."
             ])
   where

--- a/command-line/lib/Command/Address/Delegation.hs
+++ b/command-line/lib/Command/Address/Delegation.hs
@@ -62,7 +62,7 @@ mod liftCmd = command "delegation" $
             , indent 2 $ string ""
             , indent 2 $ bold $ string "$ cat addr.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public \\"
-            , indent 4 $ bold $ string $ "| "<>progName<>" address payment --network-tag 0 \\"
+            , indent 4 $ bold $ string $ "| "<>progName<>" address payment --network-tag testnet \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" address delegation $(cat stake.prv | "<>progName<>" key public)"
             , indent 2 $ string "addr1qpj2d4dqzds5p3mmlu95v9pex2d72cdvyjh2u3dtj4yqesv27k..."
             ])

--- a/command-line/lib/Command/Address/Inspect.hs
+++ b/command-line/lib/Command/Address/Inspect.hs
@@ -64,7 +64,7 @@ mod liftCmd = command "inspect" $
             , string "Example:"
             , indent 2 $ bold $ string "$ cat addr.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public \\"
-            , indent 4 $ bold $ string $ "| "<>progName<>" address payment --network-tag 0 \\"
+            , indent 4 $ bold $ string $ "| "<>progName<>" address payment --network-tag testnet \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" address delegation $(cat stake.prv | "<>progName<>" key public) \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" address inspect"
             , indent 2 $ string "{"

--- a/command-line/lib/Command/Address/Payment.hs
+++ b/command-line/lib/Command/Address/Payment.hs
@@ -58,7 +58,7 @@ mod liftCmd = command "payment" $
             , indent 2 $ string ""
             , indent 2 $ bold $ string "$ cat addr.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public \\"
-            , indent 4 $ bold $ string $ "| "<>progName<>" address payment --network-tag 0"
+            , indent 4 $ bold $ string $ "| "<>progName<>" address payment --network-tag testnet"
             , indent 2 $ string "addr_test1vqrlltfahghjxl5sy5h5mvfrrlt6me5fqphhwjqvj5jd88cccqcek"
             ])
   where

--- a/command-line/lib/Command/Address/Reward.hs
+++ b/command-line/lib/Command/Address/Reward.hs
@@ -63,7 +63,7 @@ mod liftCmd = command "stake" $
             , indent 2 $ string ""
             , indent 2 $ bold $ string "$ cat stake.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public \\"
-            , indent 4 $ bold $ string $ "| "<>progName<>" address stake --network-tag 0"
+            , indent 4 $ bold $ string $ "| "<>progName<>" address stake --network-tag testnet"
             , indent 2 $ string "stake_test1uzp7swuxjx7wmpkkvat8kpgrmjl8ze0dj9lytn25qv2tm4g6n5c35"
             ])
   where

--- a/command-line/test/Command/Address/BootstrapSpec.hs
+++ b/command-line/test/Command/Address/BootstrapSpec.hs
@@ -13,47 +13,64 @@ import Test.Utils
 
 spec :: Spec
 spec = describeCmd [ "address", "bootstrap" ] $ do
-    specIcarus defaultPhrase "44H/1815H/0H/0/0" 764824073
+    specIcarus defaultPhrase "44H/1815H/0H/0/0" "764824073"
         "Ae2tdPwUPEYz6ExfbWubiXPB6daUuhJxikMEb4eXRp5oKZBKZwrbJ2k7EZe"
-    specIcarus defaultPhrase "44H/1815H/0H/0/1" 764824073
+    specIcarus defaultPhrase "44H/1815H/0H/0/1" "764824073"
         "Ae2tdPwUPEZCJUCuVgnysar8ZJeyKuhjXU35VNgKMMTcXWmS9zzYycmwKa4"
-    specIcarus defaultPhrase "44H/1815H/0H/0/2" 764824073
+    specIcarus defaultPhrase "44H/1815H/0H/0/2" "764824073"
         "Ae2tdPwUPEZFJtMH1m5HvsaQZrmgLcVcyuk5TxYtdRHZFo8yV7yEnnJyqTs"
 
-    specByron defaultPhrase "0H/0H" 764824073
+    specIcarus defaultPhrase "44H/1815H/0H/0/0" "mainnet"
+        "Ae2tdPwUPEYz6ExfbWubiXPB6daUuhJxikMEb4eXRp5oKZBKZwrbJ2k7EZe"
+    specIcarus defaultPhrase "44H/1815H/0H/0/1" "mainnet"
+        "Ae2tdPwUPEZCJUCuVgnysar8ZJeyKuhjXU35VNgKMMTcXWmS9zzYycmwKa4"
+    specIcarus defaultPhrase "44H/1815H/0H/0/2" "mainnet"
+        "Ae2tdPwUPEZFJtMH1m5HvsaQZrmgLcVcyuk5TxYtdRHZFo8yV7yEnnJyqTs"
+
+    specByron defaultPhrase "0H/0H" "764824073"
         "DdzFFzCqrhsf6hiTYkK5gBAhVDwg3SiaHiEL9wZLYU3WqLUpx6DP\
         \5ZRJr4rtNRXbVNfk89FCHCDR365647os9AEJ8MKZNvG7UKTpythG"
-    specByron defaultPhrase "0H/1H" 764824073
+    specByron defaultPhrase "0H/1H" "764824073"
         "DdzFFzCqrhssdAorKQ7hGGPgNS3akoiuNG6YY7bb11hYrm1x716e\
         \akbz3yUppMS6X4t8WgM3Nx9CwjqZk3oNgm8s9yooJTs5AS7ptFT6"
-    specByron defaultPhrase "0H/2H" 764824073
+    specByron defaultPhrase "0H/2H" "764824073"
+        "DdzFFzCqrht4YH5irxboFprowLYgJLddd2iCQt5mrVyQS5CZFMeZ\
+        \bQtzJsHf4a6YQhPPNxtqBVP3Drsy1tdjecqq1FK1m2oAR5J8EcVe"
+
+    specByron defaultPhrase "0H/0H" "mainnet"
+        "DdzFFzCqrhsf6hiTYkK5gBAhVDwg3SiaHiEL9wZLYU3WqLUpx6DP\
+        \5ZRJr4rtNRXbVNfk89FCHCDR365647os9AEJ8MKZNvG7UKTpythG"
+    specByron defaultPhrase "0H/1H" "mainnet"
+        "DdzFFzCqrhssdAorKQ7hGGPgNS3akoiuNG6YY7bb11hYrm1x716e\
+        \akbz3yUppMS6X4t8WgM3Nx9CwjqZk3oNgm8s9yooJTs5AS7ptFT6"
+    specByron defaultPhrase "0H/2H" "mainnet"
         "DdzFFzCqrht4YH5irxboFprowLYgJLddd2iCQt5mrVyQS5CZFMeZ\
         \bQtzJsHf4a6YQhPPNxtqBVP3Drsy1tdjecqq1FK1m2oAR5J8EcVe"
 
     specInvalidNetwork "💩"
 
-specIcarus :: [String] -> String -> Int -> String -> SpecWith ()
-specIcarus phrase path networkTag want = it ("golden icarus " <> path) $ do
+specIcarus :: [String] -> String -> String -> String -> SpecWith ()
+specIcarus phrase path networkTag want = it ("golden icarus " <> path <> " (" <> networkTag <> ")") $ do
     out <- cli [ "key", "from-recovery-phrase", "icarus" ] (unwords phrase)
        >>= cli [ "key", "child", path ]
        >>= cli [ "key", "public" ]
-       >>= cli [ "address", "bootstrap", "--network-tag", show networkTag ]
+       >>= cli [ "address", "bootstrap", "--network-tag", networkTag ]
     out `shouldBe` want
 
-specByron :: [String] -> String -> Int -> String -> SpecWith ()
-specByron phrase path networkTag want = it ("golden byron " <> path) $ do
+specByron :: [String] -> String -> String -> String -> SpecWith ()
+specByron phrase path networkTag want = it ("golden byron " <> path <> " (" <> networkTag <> ")") $ do
     rootPrv <- cli [ "key", "from-recovery-phrase", "byron" ] (unwords phrase)
     rootPub <- cli [ "key", "public" ] rootPrv
     out <- cli [ "key", "child", "--legacy", path ] rootPrv
        >>= cli [ "key", "public" ]
-       >>= cli [ "address", "bootstrap", "--root", rootPub, "--network-tag", show networkTag, path ]
+       >>= cli [ "address", "bootstrap", "--root", rootPub, "--network-tag", networkTag, path ]
     out `shouldBe` want
 
 specInvalidNetwork :: String -> SpecWith ()
 specInvalidNetwork networkTag = it ("invalid network " <> networkTag) $ do
     (out, err) <- cli [ "address", "bootstrap", "--network-tag", networkTag ] ""
     out `shouldBe` ""
-    err `shouldContain` "Invalid network tag. Must be a integer value."
+    err `shouldContain` "Invalid network tag. Must be an integer value or one of the allowed keywords:"
     err `shouldContain` "Usage"
 
 defaultPhrase :: [String]

--- a/command-line/test/Command/Address/PaymentSpec.hs
+++ b/command-line/test/Command/Address/PaymentSpec.hs
@@ -13,22 +13,29 @@ import Test.Utils
 
 spec :: Spec
 spec = describeCmd [ "address", "payment" ] $ do
-    specShelley defaultPhrase "1852H/1815H/0H/0/0" 0
+    specShelley defaultPhrase "1852H/1815H/0H/0/0" "0"
         "addr_test1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg57c2qv"
 
-    specShelley defaultPhrase "1852H/1815H/0H/0/0" 3
+    specShelley defaultPhrase "1852H/1815H/0H/0/0" "3"
         "addr1vdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0m9a08"
+
+    specShelley defaultPhrase "1852H/1815H/0H/0/0" "testnet"
+        "addr_test1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg57c2qv"
+
+    specShelley defaultPhrase "1852H/1815H/0H/0/0" "mainnet"
+        "addr1v9u5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0kvk0f"
 
     specMalformedNetwork "💩"
 
     specInvalidNetwork "42"
+    specInvalidNetwork "staging"
 
-specShelley :: [String] -> String -> Int -> String -> SpecWith ()
+specShelley :: [String] -> String -> String -> String -> SpecWith ()
 specShelley phrase path networkTag want = it ("golden shelley (payment) " <> path) $ do
     out <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
        >>= cli [ "key", "child", path ]
        >>= cli [ "key", "public" ]
-       >>= cli [ "address", "payment", "--network-tag", show networkTag ]
+       >>= cli [ "address", "payment", "--network-tag", networkTag ]
     out `shouldBe` want
 
 specMalformedNetwork :: String -> SpecWith ()
@@ -37,7 +44,7 @@ specMalformedNetwork networkTag = it ("malformed network " <> networkTag) $ do
         >>= cli [ "key", "public" ]
         >>= cli [ "address", "payment", "--network-tag", networkTag ]
     out `shouldBe` ""
-    err `shouldContain` "Invalid network tag. Must be a integer value."
+    err `shouldContain` "Invalid network tag. Must be an integer value or one of the allowed keywords:"
     err `shouldContain` "Usage"
 
 specInvalidNetwork :: String -> SpecWith ()
@@ -46,7 +53,7 @@ specInvalidNetwork networkTag = it ("invalid network " <> networkTag) $ do
         >>= cli [ "key", "public" ]
         >>= cli [ "address", "payment", "--network-tag", networkTag ]
     out `shouldBe` ""
-    err `shouldContain` "Invalid network tag. Must be between"
+    err `shouldContain` "Invalid network tag."
 
 defaultPhrase :: [String]
 defaultPhrase =


### PR DESCRIPTION
```console
$ cardano-address address bootstrap --help                                                                                                     ±[●][KtorZ/nicer--network-tag]
Those addresses, now deprecated, were used during the Byron era.

Usage: cardano-address address bootstrap [--root XPUB] --network-tag NETWORK-TAG
                                         [DERIVATION-PATH]
  Create a bootstrap address

Available options:
  -h,--help                Show this help text
  --root XPUB              A root public key. Needed for Byron addresses only.
  --network-tag NETWORK-TAG
                           A tag which identifies a Cardano network.
                           
                           ┌ Byron / Icarus ──────────
                           │ 
                           │ mainnet
                           │ staging
                           │ testnet
                           
                           ...or alternatively, an explicit network tag as an integer.
  DERIVATION-PATH          Slash-separated derivation path. Hardened indexes are
                           marked with a 'H' (e.g. 1852H/1815H/0H/0).

Example:
  $ cardano-address recovery-phrase generate --size 12 \
    | cardano-address key from-recovery-phrase Byron > root.prv
  
  $ cat root.prv \
    | cardano-address key child --legacy 14H/42H > addr.prv
    | cardano-address key public \
    | cardano-address address bootstrap --root $(cat root.prv | cardano-address key public) \
        --network-tag testnet 14H/42H
  DdzFFzCqrht2KG1vWt5WGhVC9Ezyu32RgB5M2DocdZ6BQU6zj69LSqksDmdM...
```

```console
$ cardano-address address payment --help                                                                                                       ±[●][KtorZ/nicer--network-tag]
Payment addresses carry no delegation rights whatsoever.

Usage: cardano-address address payment --network-tag NETWORK-TAG
  Create a payment address

Available options:
  -h,--help                Show this help text
  --network-tag NETWORK-TAG
                           A tag which identifies a Cardano network.
                           
                           ┌ Shelley ─────────────────
                           │ 
                           │ mainnet
                           │ testnet
                           
                           ...or alternatively, an explicit network tag as an integer.

Example:
  $ cardano-address recovery-phrase generate --size 15 \
    | cardano-address key from-recovery-phrase Shelley > root.prv
  
  $ cat root.prv \
    | cardano-address key child 1852H/1815H/0H/0/0 > addr.prv
  
  $ cat addr.prv \
    | cardano-address key public \
    | cardano-address address payment --network-tag testnet
  addr_test1vqrlltfahghjxl5sy5h5mvfrrlt6me5fqphhwjqvj5jd88cccqcek
```
