### PR TITLE
Fix extra-source-files in cardano-addresses-cli.cabal

### DIFF
--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -20,7 +20,7 @@ license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
-    ../schemas/address-inspect.json
+    ./schemas/address-inspect.json
 
 source-repository head
   type: git

--- a/command-line/package.yaml
+++ b/command-line/package.yaml
@@ -12,7 +12,7 @@ description: |
   Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>
 
 extra-source-files:
-  ../schemas/address-inspect.json
+  ./schemas/address-inspect.json
 
 dependencies:
 - base >= 4.7 && < 5

--- a/command-line/schemas/address-inspect.json
+++ b/command-line/schemas/address-inspect.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$id": "https://raw.githubusercontent.com/input-output-hk/cardano-addresses/master/schemas/address-inspect.json",
+  "$id": "https://raw.githubusercontent.com/input-output-hk/cardano-addresses/master/command-line/schemas/address-inspect.json",
   "description": "JSON specification for address inspection.",
   "type": "object",
   "required": [

--- a/command-line/test/Command/Address/InspectSpec.hs
+++ b/command-line/test/Command/Address/InspectSpec.hs
@@ -104,7 +104,7 @@ specInspectAddress mustHave args addr = it addr $ do
             es -> expectationFailure $ "invalid JSON: " <> unlines (show <$> es)
   where
     schema :: SchemaRef
-    schema = "../schemas/address-inspect.json"
+    schema = "./schemas/address-inspect.json"
 
 specInspectMalformed :: String -> SpecWith ()
 specInspectMalformed str = it ("malformed: " <> str) $ do


### PR DESCRIPTION
../ directories are not allowed and will most likely be
parse errors (for both cabal and stack) in the near future.