### PR TITLE
Improve Script parser errors and support for key parsing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,197 +25,119 @@ API documentation is available [here](https://input-output-hk.github.io/cardano-
 
 > :bulb: Most commands read argument from the standard input. This prevent sensitive information from appearing into your shell history and, makes it easy to pipe commands!
 
-Here's are some key examples:
-
 <details>
-  <summary>How to generate a recovery phrase</summary>
+  <summary>How to generate a recovery phrase (<strong>phrase.prv</strong>)</summary>
 
-```
-$ cardano-address recovery-phrase generate --size 15 > recovery-phrase.txt
-east student silly already breeze enact seat trade few way online skin grass humble electric
+```console
+$ cardano-address recovery-phrase generate --size 15 > phrase.prv
+exercise club noble adult miracle awkward problem olympic puppy private goddess piano fatal fashion vacuum
 ```
 </details>
 
 <details>
-  <summary>How to generate a root private key</summary>
+  <summary>How to generate a root private key (<strong>root.xsk</strong>)</summary>
 
-```
-$ cat recovery-phrase.txt | cardano-address key from-recovery-phrase Shelley
-root_xsk1zz8x2k6jemuq884k4s4c862n2maaskk07ua7xc4pcegfd70fx9ymnhrk5jkex5rh5fggph0682rdxjpaf97lkrmqqs49md3mq0n5ds4e07en8xnyn3g3f85zn85gapcwkht6y5djqrjmqdnqp2rg5nvmyc99drac
+```console
+$ cardano-address key from-recovery-phrase Shelley < phrase.prv > root.xsk
+root_xsk1hqzfzrgskgnpwskxxrv5khs7ess82ecy8za9l5ef7e0afd2849p3zryje8chk39nxtva0sww5me3pzkej4rvd5cae3q3v8eu7556n6pdrp4fdu8nsglynpmcppxxvfdyzdz5gfq3fefjepxhvqspmuyvmvqg8983
 ```
 
-Notice the `root_xsk` prefix to identify a root extended signing (private) key.
+> :information_source: Notice the `root_xsk` prefix to identify a root extended signing (private) key.
 </details>
 
 <details>
-  <summary>How to generate an extended public stake key (public key plus chain code)</summary>
+  <summary>How to generate a payment verification key (<strong>addr.xvk</strong>)</summary>
 
+```console
+$ cardano-address key child 1852H/1815H/0H/0/0 < root.xsk | cardano-address key public --with-chain-code > addr.xvk
+addr_xvk1grvg8qzmkmw2n0dm4pd0h3j4dv6yglyammyp733eyj629dc3z28v6wk22nfmru6xz0vl2s3y5xndyd57fu70hrt84c6zkvlwx6fdl7ct9j7yc
 ```
-$ cardano-address recovery-phrase generate --size 15 > recovery-phrase.txt
-$ cat recovery-phrase.txt | cardano-address key from-recovery-phrase Shelley \
-| cardano-address key child 1852H/1815H/0H/2/0 \
-| cardano-address key public --with-chain-code
-stake_xvk16apaenn9ut6s40lcw3l8v68xawlrlq20z2966uzcx8jmv2q9uy7yak6lmcyst8yclpm3yalrspc7q2wy9f6683x6f9z4e3gclhs5snslcst62
-```
-Notice the `stake_xvk` prefix to identify a stake extended verification (public) key.
 
-> :information_source: `1852H/1815H/0H/2/0` is the derivation path that is typically used by Cardano wallet to identify a stake key within HD wallet. If you seek compatibility with Daedalus or Yoroi, use this as well!
-
+> :information_source: The last segment in the path is the key index and can be incremented up to `2^31-1` to derive more keys.
 </details>
 
 <details>
-  <summary>How to generate a public stake key (public key without chain code)</summary>
+  <summary>How to generate a stake verification key (<strong>stake.xvk</strong>)</summary>
 
+```console
+$ cardano-address key child 1852H/1815H/0H/2/0 < root.xsk | cardano-address key public --with-chain-code > stake.xvk
+stake_xvk1658atzttunamzn80204khrg0qfdk5nvmrutlmmpg7xlsyaggwa7h9z4smmeqsvs67qhyqmc2lqa0vy36rf2la74ym8a5p93zp4qtpuq6ky3ve
 ```
-$ cardano-address recovery-phrase generate --size 15 > recovery-phrase.txt
-$ cat recovery-phrase.txt | cardano-address key from-recovery-phrase Shelley \
-| cardano-address key child 1852H/1815H/0H/2/0 \
-| cardano-address key public --without-chain-code
-stake_vk16apaenn9ut6s40lcw3l8v68xawlrlq20z2966uzcx8jmv2q9uy7qau558d
-```
-Notice the `stake_vk` prefix to identify a stake verification (public) key.
 
-> :information_source: `1852H/1815H/0H/2/0` is the derivation path that is typically used by Cardano wallet to identify a stake key within HD wallet. If you seek compatibility with Daedalus or Yoroi, use this as well!
-
+> :information_source: The last segment in the path is the key index and can be incremented up to `2^31-1` to derive more keys.
 </details>
 
 <details>
-  <summary>How to generate a payment address from key credential</summary>
+  <summary>How to generate a script verification key (<strong>script.xvk</strong>)</summary>
 
+```console
+$ cardano-address key child 1852H/1815H/0H/3/0 < root.xsk | cardano-address key public --with-chain-code > script.xvk
+script_xvk1mg7xae48d7z4nntd35tey0jmclxaavwmk3kw2lkkt07p3s3x3yy45805manx2kj2neg40kfpy9em36vnkjfm4fw09k66837unrvd70qj75eg0
 ```
-  $ cardano-address recovery-phrase generate --size 15 \
-  | cardano-address key from-recovery-phrase Shelley | tee root.prv
 
-  root_xsk1fqf5s0s7mluhs8q8xduvhy9rgxgj90x8yg0ht92ymhr775k3uap4zxvh4fzcqtg7j9ewvag3lsgswryav3w650gul4mza65nrp6vdx5dt8xelgx87avxcwfqwkajm7masntd3ef3duwj39pnacupl68u4yw4ss9h
+> :information_source: The last segment in the path is the key index and can be incremented up to `2^31-1` to derive more keys.
+</details>
 
-  $ cat root.prv \
-  | cardano-address key child 1852H/1815H/0H/0/0 | tee addr.prv
-
-  addr_xsk1krnkg5uyxgdxxpkzrwscr99d0ln9dylg84qspktsvgj42c73uaplrzymsrvef3qsq0mqy8hjxk9m00k9yexym3578lxzszfanmr83cu9jhm9nzmwnfnps36gcz4d328cz49eqtgq4whl2ev402f5ae0ht5kenmd2
-
-  $ cat addr.prv \
-  | cardano-address key public --with-chain-code \
-  | cardano-address address payment --network-tag testnet
-
-  addr_test1vq3a2mkasqfmsc5y5tguuckqaxa3pafrxs9x26d2hqvjehc8dk63q
+<details>
+  <summary>How to generate a payment address from a payment key (<strong>payment.addr</strong>)</summary>
+  
+```console
+$ cardano-address address payment --network-tag testnet < addr.xvk > payment.addr
+addr_test1vp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f7guscp6v
 ```
 </details>
 
 <details>
-  <summary>How to generate a delegation address from stake key credentials</summary>
-
-  Follow the steps from 'How to generate a payment address'. Then, simply extend
-  an existing payment address with a stake key!
-
-```
-  $ cat root.prv \
-  | cardano-address key child 1852H/1815H/0H/2/0 \
-  | tee stake.prv
-
-  stake_xsk1pr95hal8lfp4wnq4m9zmvv9emy9hakx0h73qh5zkzeprxek3uapayt7qhelgfgvxx40wqr0g9j5rfwg56ujvlc5thfhrctkqld3gegyc24jf0jp59qkk8xcgqztdp762wmcx5km4w8duh77xjfx6m3yw6qw65q6w
-
-  $ cat addr.prv \
-  | cardano-address key public --with-chain-code \
-  | cardano-address address payment --network-tag testnet \
-  | cardano-address address delegation $(cat stake.prv | cardano-address key public --with-chain-code)
-
-  addr_test1qq3a2mkasqfmsc5y5tguuckqaxa3pafrxs9x26d2hqvjehesytwfe2p0tt06y5ptxwvvm6lfu255dny7yz8e9kv4e83qwwzy29
+  <summary>How to generate a delegated payment address from a stake key (<strong>payment-delegated.addr</strong>)</summary>
+  
+```console
+$ cardano-address address delegation $(cat stake.xvk) < payment.addr > payment-delegated.addr
+addr_test1qp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f70k6tew7wrnx0s4465nx05ajz890g44z0kx6a3gsnms4c4qq8ve0n
 ```
 </details>
 
 <details>
-  <summary>How to construct a script and calculate its hash</summary>
-
-  Let's say I have the following recovery phrase
-```
-$ cat recovery-phrase.txt
-east student silly already breeze enact seat trade few way online skin grass humble electric
-```
- Now we create root key
-```
-$ cat recovery-phrase.txt \
-| cardano-address key from-recovery-phrase Shelley \
-| tee root.xpr
-
-root_xsk1zz8x2k6jemuq884k4s4c862n2maaskk07ua7xc4pcegfd70fx9ymnhrk5jkex5rh5fggph0682rdxjpaf97lkrmqqs49md3mq0n5ds4e07en8xnyn3g3f85zn85gapcwkht6y5djqrjmqdnqp2rg5nvmyc99drac
-```
- And derive two signing keys according to multisig CIP (TO-DO add link when available)
-```
-$ cat root.xprv \
-| cardano-address key child 1852H/1815H/0H/3/0 \
-| tee signingKey1.xprv
-
-script_xsk1tr75z5eem5gxxredy7qj63v95vudfwfrmd0cd0772exekr02x9y6nhnranafyws2d0e5r0du87f0llu4dpdwsrlgxafwlwv7vzsanwa79jjj269v36uqekx368myrrqxe4u86dw0t0ncnjjn6wc8w57pmu5gdsr4
-
-$ cat root.xprv \
-| cardano-address key child 1852H/1815H/0H/3/1 \
-| tee signingKey2.xprv
-
-script_xsk1krdfq60htlc58s6gq4uesytc74vzsa99d9yzpwlyhd2gwzl2x9ya5vhfkt4yzqu4k3v7h3kr00ey983n4er2sl3eftds28hegx5f5hq6x73l4v26e08jcyq3dhwdru6fq9nc54evkktec0hgh5dw7g0uqvnhm24p
-```
- The corresponding verification keys and their hashes can be obtained as follows
-```
-$ cat signingKey1.xprv \
-| cardano-address key public --without-chain-code \
-| cardano-address key hash \
-| tee verKey1.hash
-
-script_vkh15thv7uqqd0jh48fv4achd7ufqu9kv98c78r40q7fpwylw2c6wft
-
-$ cat signingKey2.xprv \
-| cardano-address key public --without-chain-code \
-| cardano-address key hash \
-| tee verKey2.hash
-
-script_vkh18w06sur9ll7pcw8nzzr9mllgzyrrraaqse8336k2ej2cyph0u2a
-```
- Notice the `script_vkh` prefix to identify the hash of verification key.
-
- Now we can construct the script using the hashes of verification keys
-```
-$ echo "all [$(cat verKey1.hash),$(cat verKey2.hash)]" | tee script.txt
-
-all [script_vkh15thv7uqqd0jh48fv4achd7ufqu9kv98c78r40q7fpwylw2c6wft,script_vkh18w06sur9ll7pcw8nzzr9mllgzyrrraaqse8336k2ej2cyph0u2a]
-```
- Having a script constructed we can get its script hash that could go to payment or delegation credential
- when creating the address. Notice the `script` prefix to identify the hash of the script.
-
-```
-$ cardano-address script hash "$(cat script.txt)"
-
-script1qd46g66dq98dh8h2qh947wq3qajf3plmlnkkedn2yexxke2lahd
+  <summary>How to generate a stake address from a stake key (<strong>stake.addr</strong>)</summary>
+  
+```console
+$ cardano-address address stake --network-tag testnet < stake.xvk > stake.addr
+stake_test1urmd9uh08pen8c26a2fn86weprjh52638mrdwc5gfac2u2s25zpat%
 ```
 </details>
 
 <details>
-  <summary>How to generate a payment address from script credential</summary>
+  <summary>How to construct a multisig script hash (<strong>script.hash</strong>)</summary>
 
+We consider `script.1.xvk` and `script.2.xvk` obtained like `script.xvk` but by replacing the final index by `1` and `2` respectively.
+
+```console
+$ cardano-address script hash "all [$(cat script.1.xvk), $(cat script.2.xvk)]" > script.hash
+script1qzzzlvn435jzdpm9dz5sk5helh6u2n5wa7g49m03sk4lzxhsxgt
 ```
-  $ cardano-address script hash "$(cat script.txt)" \
-  | cardano-address address payment --network-tag testnet
 
-  addr_test1wqpkhfrtf5q5aku7agzukheczyrkfxy8l07w6m9kdgnyc6crtxw6n
+This script requires the signature from both signing keys corresponding to `script.1.xvk` and `script.2.xvk` in order to be valid. Similarly, we could require only one of the two signatures:
+
+```console
+$ cardano-address script hash "any [$(cat script.1.xvk), $(cat script.2.xvk)]" 
+script19raudr366cluzcwjxu67v7w50dazvxc0xtyfjy99wvmd593squy
+```
+
+which is equivalent to:
+
+```console
+$ cardano-address script hash "at_least 1 [$(cat script.1.xvk), $(cat script.2.xvk)]" 
+script1dnt66jufkgx8rqxypxtz0hcrxs6hhayuj9cqh0eca82lcpwawd4
 ```
 </details>
 
 <details>
-  <summary>How to generate a delegation address from script key credentials having key payment</summary>
-
-  Follow the steps from 'How to generate a payment address'. Then, simply extend
-  an existing payment address with a stake key!
-
-```
-  $ cat root.prv \
-  | cardano-address key child 1852H/1815H/0H/2/0 > stake.prv
-
-  $ cat addr.prv \
-  | cardano-address key public --with-chain-code \
-  | cardano-address address payment --network-tag testnet \
-  | cardano-address address delegation $(cardano-address script hash "$(cat script.txt)")
-  addr_test1yqqc24zex4mqch3hp5q7da87mwufkl7hncg472phe74ea2...
+  <summary>How to generate a payment script address from a script hash (<strong>script.addr</strong>)</summary>
+  
+```console
+$ cardano-address address payment --network-tag testnet < script.hash > script.addr
+addr_test1wqqggtajwkxjgf58v452jz6jl87lt32w3mhez5hd7xz6hugp80tta
 ```
 </details>
-
 
 ## Docker Image
 

--- a/command-line/lib/Command/Key/Hash.hs
+++ b/command-line/lib/Command/Key/Hash.hs
@@ -68,7 +68,13 @@ run Hash = do
                 fail "data should be a 32-byte public key."
 
     prefixFor hrp
-        | hrp == CIP5.addr_vk   = CIP5.addr_vkh
-        | hrp == CIP5.stake_vk  = CIP5.stake_vkh
-        | hrp == CIP5.script_vk = CIP5.script_vkh
+        | hrp == CIP5.addr_vk    = CIP5.addr_vkh
+        | hrp == CIP5.addr_xvk   = CIP5.addr_vkh
+
+        | hrp == CIP5.stake_vk   = CIP5.stake_vkh
+        | hrp == CIP5.stake_xvk  = CIP5.stake_vkh
+
+        | hrp == CIP5.script_vk  = CIP5.script_vkh
+        | hrp == CIP5.script_xvk = CIP5.script_vkh
+
         | otherwise = error "impossible: pattern-match not coverage all cases."

--- a/command-line/test/Command/Key/HashSpec.hs
+++ b/command-line/test/Command/Key/HashSpec.hs
@@ -14,11 +14,17 @@ import Test.Utils
 spec :: Spec
 spec = describeCmd [ "key", "hash" ] $ do
     specKeyNotPublic
-    specKeyPublic "addr_vkh"   "1852H/1815H/0H/0/0"
-    specKeyPublic "addr_vkh"   "1852H/1815H/0H/1/0"
-    specKeyPublic "stake_vkh"  "1852H/1815H/0H/2/0"
-    specKeyPublic "script_vkh" "1852H/1815H/0H/3/0"
-    specKeyPublic "script_vkh" "1852H/1815H/0H/4/0"
+    specKeyPublic "addr_vkh"   "1852H/1815H/0H/0/0" "--without-chain-code"
+    specKeyPublic "addr_vkh"   "1852H/1815H/0H/1/0" "--without-chain-code"
+    specKeyPublic "stake_vkh"  "1852H/1815H/0H/2/0" "--without-chain-code"
+    specKeyPublic "script_vkh" "1852H/1815H/0H/3/0" "--without-chain-code"
+    specKeyPublic "script_vkh" "1852H/1815H/0H/4/0" "--without-chain-code"
+
+    specKeyPublic "addr_vkh"   "1852H/1815H/0H/0/0" "--with-chain-code"
+    specKeyPublic "addr_vkh"   "1852H/1815H/0H/1/0" "--with-chain-code"
+    specKeyPublic "stake_vkh"  "1852H/1815H/0H/2/0" "--with-chain-code"
+    specKeyPublic "script_vkh" "1852H/1815H/0H/3/0" "--with-chain-code"
+    specKeyPublic "script_vkh" "1852H/1815H/0H/4/0" "--with-chain-code"
 
 specKeyNotPublic :: SpecWith ()
 specKeyNotPublic = it "fail if key isn't public" $ do
@@ -29,11 +35,11 @@ specKeyNotPublic = it "fail if key isn't public" $ do
     out `shouldBe` ""
     err `shouldContain` "Invalid human-readable prefix."
 
-specKeyPublic :: String -> String -> SpecWith ()
-specKeyPublic hrp path = it "succeds if key is public" $ do
+specKeyPublic :: String -> String -> String -> SpecWith ()
+specKeyPublic hrp path cc = it "succeeds if key is public" $ do
     out <- cli [ "recovery-phrase", "generate" ] ""
        >>= cli [ "key", "from-recovery-phrase", "icarus" ]
        >>= cli [ "key", "child", path ]
-       >>= cli [ "key", "public", "--without-chain-code" ]
+       >>= cli [ "key", "public", cc ]
        >>= cli [ "key", "hash" ]
     out `shouldStartWith` hrp

--- a/command-line/test/Command/ScriptSpec.hs
+++ b/command-line/test/Command/ScriptSpec.hs
@@ -40,6 +40,15 @@ spec = do
         specScriptHashProper "script1dalltthzqnpd06fukp6j4s026wsnwrrf9k0lytzg0hnj64tfxdm"
             [iii|at_least 1 [ #{verKeyH1}, all [ #{verKeyH2}, #{verKeyH3} ] ]|]
 
+        specScriptHashProper "script1gtq9tzn6c82dzjquvn6aw5kj3s2rny6au3lejsymf96azkvdfqc"
+            [iii|#{verKeyH4}|]
+
+        specScriptHashProper "script1gtq9tzn6c82dzjquvn6aw5kj3s2rny6au3lejsymf96azkvdfqc"
+            [iii|#{verKey4}|]
+
+        specScriptHashProper "script1gtq9tzn6c82dzjquvn6aw5kj3s2rny6au3lejsymf96azkvdfqc"
+            [iii|#{verExtKey4}|]
+
         specScriptInvalid Malformed
             [iii|wrong [ #{verKeyH1} ]|]
 
@@ -64,7 +73,7 @@ spec = do
         specScriptInvalid DuplicateSignatures
             [iii|any [ #{verKeyH1}, #{verKeyH2}, #{verKeyH1}]|]
 
-        specScriptInvalid WrongKeyHash
+        specScriptInvalid Malformed
             [iii|script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxjq8egs9|]
 
 specScriptHashProper :: String -> String -> SpecWith ()
@@ -86,3 +95,12 @@ verKeyH2 = "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyrenxv223vj"
 
 verKeyH3 :: String
 verKeyH3 = "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyre5g2sfvk2"
+
+verExtKey4 :: String
+verExtKey4 = "script_xvk1mjr5lrrlxuvelx94hu2cttmg5pp6cwy5h0sa37qvpcd07pv9g23nlvugj5ez9qfxxvkmjwnpn69s48cv572phfy6qpmnwat0hwcdrasapqewe"
+
+verKey4 :: String
+verKey4 = "script_vk1mjr5lrrlxuvelx94hu2cttmg5pp6cwy5h0sa37qvpcd07pv9g23skqaly0"
+
+verKeyH4 :: String
+verKeyH4 = "script_vkh14uwy4ftq7d6wzpk5trrc5rlqss52tqp3qkrqk95hegls54e0sga"

--- a/core/lib/Cardano/Address/Script/Parser.hs
+++ b/core/lib/Cardano/Address/Script/Parser.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS_HADDOCK prune #-}
@@ -26,16 +25,15 @@ module Cardano.Address.Script.Parser
 
 import Prelude
 
-import Cardano.Address.Derivation
-    ( credentialHashSize )
 import Cardano.Address.Script
-    ( KeyHash (..), Script (..) )
-import Control.Monad
-    ( when )
+    ( ErrValidateScript (..)
+    , KeyHash (..)
+    , Script (..)
+    , prettyErrValidateScript
+    , validateScript
+    )
 import Data.Char
     ( isDigit, isLetter )
-import Data.Foldable
-    ( traverse_ )
 import Data.Functor
     ( ($>) )
 import Data.Word
@@ -44,8 +42,6 @@ import Text.ParserCombinators.ReadP
     ( ReadP, readP_to_S, (<++) )
 
 import qualified Codec.Binary.Bech32 as Bech32
-import qualified Data.ByteString as BS
-import qualified Data.List as L
 import qualified Data.Text as T
 import qualified Text.ParserCombinators.ReadP as P
 
@@ -57,69 +53,6 @@ scriptFromString str =
     case readP_to_S scriptParser str of
          [(script, "")] -> validateScript script $> script
          _ -> Left Malformed
-
--- | Validate a 'Script', semantically
---
--- @since 3.0.0
-validateScript :: Script -> Either ErrValidateScript ()
-validateScript = \case
-    RequireSignatureOf (KeyHash bytes) -> do
-        when (BS.length bytes /= credentialHashSize) $ Left WrongKeyHash
-
-    RequireAllOf script -> do
-        when (L.null script) $ Left EmptyList
-        when (hasDuplicate script) $ Left DuplicateSignatures
-        traverse_ validateScript script
-
-    RequireAnyOf script -> do
-        when (L.null script) $ Left EmptyList
-        when (hasDuplicate script) $ Left DuplicateSignatures
-        traverse_ validateScript script
-
-    RequireSomeOf m script -> do
-        when (m == 0) $ Left MZero
-        when (length script < fromIntegral m) $ Left ListTooSmall
-        when (hasDuplicate script) $ Left DuplicateSignatures
-        traverse_ validateScript script
-  where
-    hasDuplicate xs = do
-        length sigs /= length (L.nub sigs)
-      where
-        sigs = [ sig | RequireSignatureOf sig <- xs ]
-
--- | Possible validation errors when validating a script
---
--- @since 3.0.0
-data ErrValidateScript
-    = EmptyList
-    | ListTooSmall
-    | MZero
-    | DuplicateSignatures
-    | WrongKeyHash
-    | Malformed
-    deriving (Eq, Show)
-
--- | Pretty-print a validation error.
---
--- @since 3.0.0
-prettyErrValidateScript
-    :: ErrValidateScript
-    -> String
-prettyErrValidateScript = \case
-    EmptyList ->
-        "The list inside a script is empty."
-    MZero ->
-        "The M in at_least cannot be 0."
-    ListTooSmall ->
-        "The list inside at_least cannot be less than M."
-    DuplicateSignatures ->
-        "The list inside a script has duplicate keys."
-    WrongKeyHash ->
-        "The hash of verification key is expected to have "<>show credentialHashSize<>" bytes."
-    Malformed ->
-        "Parsing of the script failed. The script should be composed of nested \
-        \lists, and the verification keys should be either encoded as bech32."
-
 
 -- | The script embodies combination of signing keys that need to be met to make
 -- it valid. We assume here that the script could


### PR DESCRIPTION
- 25e199d5b8dc2e6b233556980b06761476032283
  :round_pushpin: **improve parsing error for 'Script' FromJSON instance**
    And in particular, run the validation also in the JSON parser. I've added a few negative test scenarios to show what errors look like.

- c4b9db9a8debd3882509dd82888efa8b1ea69e81
  :round_pushpin: **make 'keyHashFromText' works from key, extended keys and key hashes seamlessly.**
    This also impacts the command-line parser and the JSON parser to have the same behavior.
