### PR TITLE
fix missing pattern-match in the key hash command.

### DIFF
--- a/command-line/lib/Command/Key/Hash.hs
+++ b/command-line/lib/Command/Key/Hash.hs
@@ -68,7 +68,13 @@ run Hash = do
                 fail "data should be a 32-byte public key."
 
     prefixFor hrp
-        | hrp == CIP5.addr_vk   = CIP5.addr_vkh
-        | hrp == CIP5.stake_vk  = CIP5.stake_vkh
-        | hrp == CIP5.script_vk = CIP5.script_vkh
+        | hrp == CIP5.addr_vk    = CIP5.addr_vkh
+        | hrp == CIP5.addr_xvk   = CIP5.addr_vkh
+
+        | hrp == CIP5.stake_vk   = CIP5.stake_vkh
+        | hrp == CIP5.stake_xvk  = CIP5.stake_vkh
+
+        | hrp == CIP5.script_vk  = CIP5.script_vkh
+        | hrp == CIP5.script_xvk = CIP5.script_vkh
+
         | otherwise = error "impossible: pattern-match not coverage all cases."

--- a/command-line/test/Command/Key/HashSpec.hs
+++ b/command-line/test/Command/Key/HashSpec.hs
@@ -14,11 +14,17 @@ import Test.Utils
 spec :: Spec
 spec = describeCmd [ "key", "hash" ] $ do
     specKeyNotPublic
-    specKeyPublic "addr_vkh"   "1852H/1815H/0H/0/0"
-    specKeyPublic "addr_vkh"   "1852H/1815H/0H/1/0"
-    specKeyPublic "stake_vkh"  "1852H/1815H/0H/2/0"
-    specKeyPublic "script_vkh" "1852H/1815H/0H/3/0"
-    specKeyPublic "script_vkh" "1852H/1815H/0H/4/0"
+    specKeyPublic "addr_vkh"   "1852H/1815H/0H/0/0" "--without-chain-code"
+    specKeyPublic "addr_vkh"   "1852H/1815H/0H/1/0" "--without-chain-code"
+    specKeyPublic "stake_vkh"  "1852H/1815H/0H/2/0" "--without-chain-code"
+    specKeyPublic "script_vkh" "1852H/1815H/0H/3/0" "--without-chain-code"
+    specKeyPublic "script_vkh" "1852H/1815H/0H/4/0" "--without-chain-code"
+
+    specKeyPublic "addr_vkh"   "1852H/1815H/0H/0/0" "--with-chain-code"
+    specKeyPublic "addr_vkh"   "1852H/1815H/0H/1/0" "--with-chain-code"
+    specKeyPublic "stake_vkh"  "1852H/1815H/0H/2/0" "--with-chain-code"
+    specKeyPublic "script_vkh" "1852H/1815H/0H/3/0" "--with-chain-code"
+    specKeyPublic "script_vkh" "1852H/1815H/0H/4/0" "--with-chain-code"
 
 specKeyNotPublic :: SpecWith ()
 specKeyNotPublic = it "fail if key isn't public" $ do
@@ -29,11 +35,11 @@ specKeyNotPublic = it "fail if key isn't public" $ do
     out `shouldBe` ""
     err `shouldContain` "Invalid human-readable prefix."
 
-specKeyPublic :: String -> String -> SpecWith ()
-specKeyPublic hrp path = it "succeds if key is public" $ do
+specKeyPublic :: String -> String -> String -> SpecWith ()
+specKeyPublic hrp path cc = it "succeeds if key is public" $ do
     out <- cli [ "recovery-phrase", "generate" ] ""
        >>= cli [ "key", "from-recovery-phrase", "icarus" ]
        >>= cli [ "key", "child", path ]
-       >>= cli [ "key", "public", "--without-chain-code" ]
+       >>= cli [ "key", "public", cc ]
        >>= cli [ "key", "hash" ]
     out `shouldStartWith` hrp


### PR DESCRIPTION
Just caught this while testing something else and got bitten by the "impossible: pattern-match not coverage all cases.". Obviously, test cases for this very particular thing were missing so I can only blame it on myself :upside_down_face: 
