### PR TITLE
Fix cabal package versions and bump to 3.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
         wget -O Makefile https://raw.githubusercontent.com/input-output-hk/adrestia/master/.haskell/coverage/Makefile
         mkdir -p .coverage && touch .coverage/template.overlay
         DESTDIR=dist/coverage make report && DESTDIR=dist/coverage make badge
+        echo "Checking for updated cabal files"
+        git diff --exit-code -- '*.cabal' && echo OK
 
     - name: 📎 Upload Artifact
       uses: actions/upload-artifact@v1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,17 +1,31 @@
+## [3.1.1] - UNRELEASED
+
+### Added
+
+N/A
+
+### Changed
+
+- Fix `cardano-address --version` reporting.
+
+### Removed
+
+N/A
+
 ## [3.1.0] - 2020-11-13
 
 ### Added
 
 N/A
 
-### Changed 
+### Changed
 
 - 'keyHashFromText' now works seamlessly with key, extended keys or key hashes. In case a key or extended key is given, the relevant part will be hashed on the fly. Said differently, it means that
-  the command-line and the JSON instance for 'Script' works transparently with keys or key hashes. 
+  the command-line and the JSON instance for 'Script' works transparently with keys or key hashes.
 
-- Fixed a bug with the `key hash` command which failed when provided with extended keys. 
+- Fixed a bug with the `key hash` command which failed when provided with extended keys.
 
-- The 'FromJSON' instance for 'Script' now runs the validation within the JSON parser, such that when the parser succeeds the resulting 'Script' is indeed valid. 
+- The 'FromJSON' instance for 'Script' now runs the validation within the JSON parser, such that when the parser succeeds the resulting 'Script' is indeed valid.
 
 - The 'FromJSON' instance for 'Script' is now much better at showing errors.
 
@@ -33,15 +47,15 @@ N/A
 
 - New command for computing key and script hashes that are required in the construction of larger objects (e.g. addresses).
 
-- Support for cabal build. 
+- Support for cabal build.
 
-### Changed 
+### Changed
 
 - The command-line API no longer support multi-encoding (base16, bech32 and base58) but instead, enforces bech32 for keys and addresses, with specific human readable prefixes. It is still possible to easily go from base16-encoded data to bech32 by piping data through the [`bech32`](https://github.com/input-output-hk/bech32/) command-line.
 
 - It is no longer possible to derive child keys to and from any path. Are only allowed:
    - root -> account
-   - root -> address 
+   - root -> address
    - account -> address
   This is reflected in the bech32 prefixes of the inputs and outputs.
 
@@ -62,9 +76,9 @@ N/A
 - Added constructors to derive keys on the multisig role.
 - Made the parser for `--network-tag` more user friendly by now accepting pre-defined keywords such as "mainnet" or "testnet".
 
-### Changed 
+### Changed
 
-- Renamed `AccountingStyle` into `Role` to better capture the semantic of the 4th level in derivation paths. 
+- Renamed `AccountingStyle` into `Role` to better capture the semantic of the 4th level in derivation paths.
 - Made script hashes 28-byte long again, after this was fixed upstream in the Cardano ledger.
 
 ### Removed
@@ -74,7 +88,7 @@ N/A
 
 ## [2.0.0] - 2020-09-10
 
-### Added 
+### Added
 
 - Command-line interface `cardano-address` for managing recovery-phrases, keys and addresses.
 - Support for Shelley-specific address types.

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2c60c039230d1233a0b41a9b74f8ea4ff9dba687274c59ed4f96d581dee0c649
+-- hash: 10fb9a8f9037d25175d79241548e13d3d3fc85ca0e14289cf1a50180093e182e
 
 name:           cardano-addresses-cli
-version:        3.0.0
+version:        3.1.1
 synopsis:       Utils for constructing a command-line on top of cardano-addresses.
 description:    Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>
 category:       Cardano

--- a/command-line/lib/System/Git/TH.hs
+++ b/command-line/lib/System/Git/TH.hs
@@ -12,6 +12,8 @@ import Control.Exception
     ( SomeException, try )
 import Language.Haskell.TH
     ( Exp (..), Lit (..), Q, runIO )
+import System.Environment
+    ( lookupEnv )
 import System.Exit
     ( ExitCode (..) )
 import System.Process
@@ -19,8 +21,13 @@ import System.Process
 
 gitRevParseHEAD :: Q Exp
 gitRevParseHEAD =
-    LitE . StringL <$> runIO runGitRevParse
+    LitE . StringL <$> runIO findGitRev
   where
+    findGitRev :: IO String
+    findGitRev = do
+        envRev <- lookupEnv "GITREV"
+        maybe runGitRevParse pure envRev
+
     runGitRevParse :: IO String
     runGitRevParse = do
         result <- try @SomeException $

--- a/command-line/package.yaml
+++ b/command-line/package.yaml
@@ -1,5 +1,5 @@
 name:                cardano-addresses-cli
-version:             3.1.0
+version:             3.1.1
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: da9461dd19f04db3ba809b58b345e675a88c580c1eb362949143a5e258e70f9d
+-- hash: 9933cf6f1c921e46ee293b618ee32235c9990b464ad93568e02554e73e3e2f6a
 
 name:           cardano-addresses
-version:        3.0.0
+version:        3.1.1
 synopsis:       Library utilities for mnemonic generation and address derivation.
 description:    Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>
 category:       Cardano

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,5 +1,5 @@
 name:                cardano-addresses
-version:             3.1.0
+version:             3.1.1
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK


### PR DESCRIPTION
### Jira ticket

ADP-552

### Overview

Fixes problems found during the cardano-wallet v2020-11-17 release.

1. Fixes the `cardano-address --version` output, and bump to 3.1.1.
2. The `GITREV` environment variable can be used at build time to set the git version info, in case this program is not being built from a git clone.
3. Add a CI check to ensure that cabal files are up-to-date with respect to the hpack source.

### Comments

Note that the CI pipeline is currently broken because github removed a function - the failure is not caused by this PR. I have built it locally.
