### PR TITLE
Extend script by timelocks

### DIFF
--- a/core/lib/Cardano/Address/Script.hs
+++ b/core/lib/Cardano/Address/Script.hs
@@ -45,9 +45,7 @@ import Control.Applicative
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( foldM )
-import Control.Monad
-    ( when )
+    ( foldM, when )
 import Data.Aeson
     ( FromJSON (..)
     , ToJSON (..)

--- a/core/lib/Cardano/Address/Script/Parser.hs
+++ b/core/lib/Cardano/Address/Script/Parser.hs
@@ -21,8 +21,6 @@ module Cardano.Address.Script.Parser
     , requireAllOfParser
     , requireAnyOfParser
     , requireAtLeastOfParser
-    , validFromSlotParser
-    , validUntilSlotParser
     ) where
 
 import Prelude
@@ -77,11 +75,11 @@ scriptFromString str =
 -- 5. Nested script are supported
 -- at_least 1 [3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe, all [3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3f1, 3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3f1]]
 -- 6. 1 signature required after slot number 120
--- all [3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe, valid_from 120]
+-- all [3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe, active_from 120]
 -- 7. 1 signature required until slot number 150
--- all [3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe, valid_until 150]
+-- all [3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe, active_until 150]
 -- 8. 1 signature required in slot interval <145, 150)
--- all [3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe, valid_from 145, valid_until 150]
+-- all [3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe, active_from 145, active_until 150]
 --
 -- Parser is insensitive to whitespaces.
 --
@@ -92,8 +90,8 @@ scriptParser =
     requireAnyOfParser <++
     requireAtLeastOfParser <++
     requireSignatureOfParser <++
-    validFromSlotParser <++
-    validUntilSlotParser
+    activeFromSlotParser <++
+    activeUntilSlotParser
 
 requireSignatureOfParser :: ReadP Script
 requireSignatureOfParser = do
@@ -121,17 +119,17 @@ requireAtLeastOfParser = do
     _identifier <- P.string "at_least"
     RequireSomeOf <$> naturalParser <*> commonPart
 
-validFromSlotParser :: ReadP Script
-validFromSlotParser = do
+activeFromSlotParser :: ReadP Script
+activeFromSlotParser = do
     P.skipSpaces
-    _identifier <- P.string "valid_from"
-    ValidFromSlot <$> slotParser
+    _identifier <- P.string "active_from"
+    ActiveFromSlot <$> slotParser
 
-validUntilSlotParser :: ReadP Script
-validUntilSlotParser = do
+activeUntilSlotParser :: ReadP Script
+activeUntilSlotParser = do
     P.skipSpaces
-    _identifier <- P.string "valid_until"
-    ValidUntilSlot <$> slotParser
+    _identifier <- P.string "active_until"
+    ActiveUntilSlot <$> slotParser
 
 naturalParser :: ReadP Word8
 naturalParser = do

--- a/core/test/Cardano/Address/Script/ParserSpec.hs
+++ b/core/test/Cardano/Address/Script/ParserSpec.hs
@@ -50,9 +50,9 @@ spec = do
     let script11 = "at_least 1 ["<>verKeyH1<>", all ["<>verKeyH2<>","<>verKeyH3<>"]]"
     let script12 = "all []"
     let script13 = "any ["<>verKeyH1<>", all [   ]]"
-    let script14 = "all ["<>verKeyH1<>", valid_from 120]"
-    let script15 = "all ["<>verKeyH1<>", valid_until 150]"
-    let script16 = "all ["<>verKeyH1<>", valid_from 120, valid_until 125]"
+    let script14 = "all ["<>verKeyH1<>", active_from 120]"
+    let script15 = "all ["<>verKeyH1<>", active_until 150]"
+    let script16 = "all ["<>verKeyH1<>", active_from 120, active_until 125]"
 
     describe "requireSignatureOfParser : unit tests" $ do
         valuesParserUnitTest requireSignatureOfParser verKeyH1
@@ -148,20 +148,20 @@ spec = do
     describe "validFromSlot unit test" $ do
         let expected = RequireAllOf
                 [ RequireSignatureOf $ KeyHash bytes1
-                , ValidFromSlot 120 ]
+                , ActiveFromSlot 120 ]
         valuesParserUnitTest scriptParser script14 expected
 
     describe "validUntilSlot unit test" $ do
         let expected = RequireAllOf
                 [ RequireSignatureOf $ KeyHash bytes1
-                , ValidUntilSlot 150 ]
+                , ActiveUntilSlot 150 ]
         valuesParserUnitTest scriptParser script15 expected
 
     describe "validUntilSlot and validFromSlot unit test" $ do
         let expected = RequireAllOf
                 [ RequireSignatureOf $ KeyHash bytes1
-                , ValidFromSlot 120
-                , ValidUntilSlot 125 ]
+                , ActiveFromSlot 120
+                , ActiveUntilSlot 125 ]
         valuesParserUnitTest scriptParser script16 expected
 
 valuesParserUnitTest

--- a/core/test/Cardano/Address/Script/ParserSpec.hs
+++ b/core/test/Cardano/Address/Script/ParserSpec.hs
@@ -50,6 +50,9 @@ spec = do
     let script11 = "at_least 1 ["<>verKeyH1<>", all ["<>verKeyH2<>","<>verKeyH3<>"]]"
     let script12 = "all []"
     let script13 = "any ["<>verKeyH1<>", all [   ]]"
+    let script14 = "all ["<>verKeyH1<>", valid_from 120]"
+    let script15 = "all ["<>verKeyH1<>", valid_until 150]"
+    let script16 = "all ["<>verKeyH1<>", valid_from 120, valid_until 125]"
 
     describe "requireSignatureOfParser : unit tests" $ do
         valuesParserUnitTest requireSignatureOfParser verKeyH1
@@ -141,6 +144,25 @@ spec = do
                 ]
         valuesParserUnitTest requireAtLeastOfParser script11 expected2
         valuesParserUnitTest scriptParser script11 expected2
+
+    describe "validFromSlot unit test" $ do
+        let expected = RequireAllOf
+                [ RequireSignatureOf $ KeyHash bytes1
+                , ValidFromSlot 120 ]
+        valuesParserUnitTest scriptParser script14 expected
+
+    describe "validUntilSlot unit test" $ do
+        let expected = RequireAllOf
+                [ RequireSignatureOf $ KeyHash bytes1
+                , ValidUntilSlot 150 ]
+        valuesParserUnitTest scriptParser script15 expected
+
+    describe "validUntilSlot and validFromSlot unit test" $ do
+        let expected = RequireAllOf
+                [ RequireSignatureOf $ KeyHash bytes1
+                , ValidFromSlot 120
+                , ValidUntilSlot 125 ]
+        valuesParserUnitTest scriptParser script16 expected
 
 valuesParserUnitTest
     :: (Eq s, Show s)

--- a/core/test/Cardano/Address/ScriptSpec.hs
+++ b/core/test/Cardano/Address/ScriptSpec.hs
@@ -184,6 +184,24 @@ spec = do
                 \5cdca063ce9c32dfae6bc6a3e47f8da07ee4fb8e1a3901559"
                 "8aa7af44362310140ff3d32ac7d1a2ecbe26da65f3d146c64b90e9e1"
 
+        it "ActivateFromSlot" $ do
+            let script = RequireAllOf [verKeyHash1, ActiveFromSlot 120]
+            checkCBORandScriptHash script
+                "008201828200581cdeeae4e895d8d57378125ed4fd540f9bf245d59f7936a504379cfc1e82041878"
+                "f0252f0e8b31694afe2e793aefa8420fe7cdefc08003fe6a911f710d"
+
+        it "ActivateUntilSlot" $ do
+            let script = RequireAllOf [verKeyHash1, ActiveUntilSlot 150]
+            checkCBORandScriptHash script
+                "008201828200581cdeeae4e895d8d57378125ed4fd540f9bf245d59f7936a504379cfc1e82051896"
+                "88bf6eca7c3bf7abc74fdb6bd8dee2ac08656a9b79bd5cccfddda058"
+
+        it "ActivateUntilSlot and ActivateUntilSlot" $ do
+            let script = RequireAllOf [verKeyHash1, ActiveFromSlot 120, ActiveUntilSlot 150]
+            checkCBORandScriptHash script
+                "008201838200581cdeeae4e895d8d57378125ed4fd540f9bf245d59f7936a504379cfc1e8204187882051896"
+                "344ff9c219027af44c14c1d7c47bdf4c14b95c93739cac0b03c41b76"
+
     describe "validateScript - errors" $ do
         it "no content in RequireAllOf" $ do
             let script = RequireAllOf []
@@ -348,8 +366,8 @@ instance Arbitrary Script where
       where
         scriptTree 0 = oneof
             [ RequireSignatureOf <$> arbitrary
-            , ValidFromSlot <$> arbitrary
-            , ValidUntilSlot <$> arbitrary
+            , ActiveFromSlot <$> arbitrary
+            , ActiveUntilSlot <$> arbitrary
             ]
         scriptTree n = do
             Positive m <- arbitrary


### PR DESCRIPTION
I have extended script to account for ActiveFromSlot and ActiveUntilSlot. I have updated all functions engaged, json instance, json generator, and script parser. also added script parser tests.

I have tested the correctness of resultant scriptHash in cardano-wallet tests -> https://github.com/input-output-hk/cardano-wallet/pull/2401 