### PR TITLE
Fix `cardano-address address bootstrap` example in cmd help

### DIFF
--- a/command-line/lib/Command/Address/Bootstrap.hs
+++ b/command-line/lib/Command/Address/Bootstrap.hs
@@ -68,7 +68,7 @@ mod liftCmd = command "bootstrap" $
             , indent 2 $ bold $ string "$ cat root.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key child 14H/42H | tee addr.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public --with-chain-code \\"
-            , indent 4 $ bold $ string $ "| "<>progName<>" address bootstrap --root $(cat root.prv | "<>progName<>" key public) \\"
+            , indent 4 $ bold $ string $ "| "<>progName<>" address bootstrap --root $(cat root.prv | "<>progName<>" key public --with-chain-code) \\"
             , indent 8 $ bold $ string "--network-tag testnet 14H/42H"
             , indent 2 $ string "DdzFFzCqrht2KG1vWt5WGhVC9Ezyu32RgB5M2DocdZ6BQU6zj69LSqksDmdM..."
             ])


### PR DESCRIPTION
- c8a866ad96636688b3504464d5aef98effb8873a
  Fix `cardano-address address bootstrap` example in cmd help


Before:

```
  $ cat root.prv \
    | cardano-address key child 14H/42H | tee addr.prv \
    | cardano-address key public --with-chain-code \
    | cardano-address address bootstrap --root $(cat root.prv | cardano-address key public) \
        --network-tag testnet 14H/42H

Usage: cardano-address key public (--without-chain-code | --with-chain-code)
  Get the public counterpart of a private key

Available options:
  -h,--help                Show this help text

The private key is read from stdin.To get extended public key pass '--with-chain-code'.To get public key pass '--without-chain-code'.
option --root: Bech32 error: string has no separator char

Usage: cardano-address address bootstrap [--root XPUB] --network-tag NETWORK-TAG
                                         [DERIVATION-PATH]
  Create a bootstrap address

```

After:

```
  $ cat root.prv \
    | cardano-address key child 14H/42H | tee addr.prv \
    | cardano-address key public --with-chain-code \
    | cardano-address address bootstrap --root $(cat root.prv | cardano-address key public --with-chain-code) \
        --network-tag testnet 14H/42H
37btjrVyb4KBmpWDYcYeA9Sr....
```
