### PR TITLE
add missing crc32 integrity check when decoding Byron/Icarus addresses.

### DIFF
--- a/command-line/test/Command/Address/InspectSpec.hs
+++ b/command-line/test/Command/Address/InspectSpec.hs
@@ -86,6 +86,10 @@ spec = describeCmd [ "address", "inspect" ] $ do
         "DdzFFzCqrht5csm2GKhnVrjzKpVHHQFNXUDhAFDyLWVY5w8ZsJRP2uhwZ\
         \q2CEAVzDZXYXa4GvggqYEegQsdKAKikFfrrCoHheLH2Jskr"
 
+    -- Invalid CRC
+    specInspectInvalid "non-matching crc32" []
+        "Ae2tdPwUPEZ5QJkfzoJgarugsX3rUVbTjg8nqTYmuy2c2msy5augpnm91ZR"
+
 specInspectAddress :: [String] -> [String] -> String -> SpecWith ()
 specInspectAddress mustHave args addr = it addr $ do
     (out, err) <- cli ([ "address", "inspect" ] <> args) addr

--- a/core/lib/Cardano/Codec/Cbor.hs
+++ b/core/lib/Cardano/Codec/Cbor.hs
@@ -254,13 +254,13 @@ decodeAddress = do
     bytes <- CBOR.decodeBytes
         -- Addr Root + Attributes + Type
     crc <- CBOR.decodeWord32 -- CRC
+
+    when (crc /= crc32 bytes) $ fail "non-matching crc32."
+
     -- NOTE 1:
     -- Treating addresses as a blob here, so we just re-encode them as such
     -- Ultimately for us, addresses are nothing more than a bunch of bytes that
     -- we display in a Base58 format when we have to.
-    --
-    -- NOTE 2:
-    -- We may want to check the CRC at this level as-well... maybe not.
     return $ CBOR.toStrictByteString $ mempty
         <> CBOR.encodeListLen 2
         <> CBOR.encodeTag tag
@@ -272,7 +272,8 @@ decodeAddressPayload = do
     _ <- CBOR.decodeListLenCanonicalOf 2
     _ <- CBOR.decodeTag
     bytes <- CBOR.decodeBytes
-    _ <- CBOR.decodeWord32 -- CRC
+    crc <- CBOR.decodeWord32
+    when (crc /= crc32 bytes) $ fail "non-matching crc32."
     return bytes
 
 decodeAddressDerivationPath


### PR DESCRIPTION
- 835ba729b21302c616eb3ec02f3a4001a6fce150
  :round_pushpin: **add missing crc32 integrity check when decoding Byron/Icarus addresses.**
