### PR TITLE
Better error handling for inspectAddress

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,14 +5,28 @@
 - Added `Cardano.Address.Style.Shelley.eitherInspectAddress` function
   with stronger result and error types.
 
+- Added `Cardano.Address.Style.Shared` module which define a shared wallet style
+  enabling multisig.
+
 ### Changed
 
 - The constructors of `Cardano.Address.Style.Shelley.ErrInspectAddress`
   have changed.
   Any code which pattern matches on this type will need minor changes.
 
+- A number of Bech32 prefixes were changed to account for CIP changes.
+  The whole family of `*_shared_*` prefixes were introduced to accommodate
+  newly added shared wallet style. In specific, there in no longer `script_vkh`
+  but `addr_shared_vkh` and `stake_shared_vkh` to denote spending and stake
+  verification key hashes, respectively.
+
+- `KeyHash` now needs `KeyRole` values to specify, except binary payload. It was needed
+  change to enable differentiating between spending and stake key hashes.
+
 ### Removed
 
+- Multisig related functions were deleted from `Cardano.Address.Style.Shelley` as they
+  found a new place in `Cardano.Address.Style.Shared`.
 
 ## [3.3.0] - 2021-04-09
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,20 @@
-## [3.3.0] - 2021-03-30
+## [3.4.0] - UNRELEASED
+
+### Added
+
+- Added `Cardano.Address.Style.Shelley.eitherInspectAddress` function
+  with stronger result and error types.
+
+### Changed
+
+- The constructors of `Cardano.Address.Style.Shelley.ErrInspectAddress`
+  have changed.
+  Any code which pattern matches on this type will need minor changes.
+
+### Removed
+
+
+## [3.3.0] - 2021-04-09
 
 ### Added
 

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f380e56b6b727ea7067da62533485612742dbbe2d3b2d12b134e7c8b0ed87253
+-- hash: 522505cee4e08f04e60c4ef2d817dcf46b5e24c6cd71853db1ba7797ebc822b0
 
 name:           cardano-addresses-cli
-version:        3.3.0
+version:        3.4.0
 synopsis:       Utils for constructing a command-line on top of cardano-addresses.
 description:    Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>
 category:       Cardano

--- a/command-line/package.yaml
+++ b/command-line/package.yaml
@@ -1,5 +1,5 @@
 name:                cardano-addresses-cli
-version:             3.3.0
+version:             3.4.0
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK

--- a/command-line/test/Command/Address/InspectSpec.hs
+++ b/command-line/test/Command/Address/InspectSpec.hs
@@ -52,9 +52,9 @@ spec = describeCmd [ "address", "inspect" ] $ do
         "stake1upshvetj09hxjcm9v9jxgunjv4ehxmr0d3hkcmmvdakx7mqcjv83c"
 
     -- reward account: scripthash28
-    specInspectAddress ["Shelley", "by value", "script_hash"] []
+    specInspectAddress ["Shelley", "by value", "stake_shared_hash"] []
         "stake17pshvetj09hxjcm9v9jxgunjv4ehxmr0d3hkcmmvdakx7mq36s8xc"
-    specInspectAddress ["Shelley", "by value", "script_hash_bech32"] []
+    specInspectAddress ["Shelley", "by value", "stake_shared_hash_bech32"] []
         "stake17pshvetj09hxjcm9v9jxgunjv4ehxmr0d3hkcmmvdakx7mq36s8xc"
 
     -- cardano-cli generated --testnet-magic 42 addresses

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6e0f1378dee76043634d80088e83aec23f994333a41f0060bd0a36b76f6f322c
+-- hash: 544d2e87cc39554e8ef1cf9ed0304a90282254ca43c254e70eb705a079653923
 
 name:           cardano-addresses
-version:        3.3.0
+version:        3.4.0
 synopsis:       Library utilities for mnemonic generation and address derivation.
 description:    Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>
 category:       Cardano

--- a/core/lib/Cardano/Address.hs
+++ b/core/lib/Cardano/Address.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_HADDOCK prune #-}
@@ -50,6 +51,8 @@ import Control.DeepSeq
     ( NFData )
 import Control.Monad
     ( (<=<) )
+import Data.Aeson
+    ( ToJSON (..), Value (..), object, (.=) )
 import Data.Bits
     ( Bits (testBit) )
 import Data.ByteString
@@ -188,6 +191,13 @@ data ChainPointer = ChainPointer
     } deriving stock (Generic, Show, Eq, Ord)
 instance NFData ChainPointer
 
+instance ToJSON ChainPointer where
+    toJSON ChainPointer{..} = object
+        [ "slot_num" .= slotNum
+        , "transaction_index" .= transactionIndex
+        , "output_index" .= outputIndex
+        ]
+
 -- | Encoding of pointer addresses for payment key type, pointer to delegation
 -- certificate in the blockchain and backend targets.
 --
@@ -224,6 +234,9 @@ newtype NetworkTag
     = NetworkTag { unNetworkTag :: Word32 }
     deriving (Generic, Show, Eq)
 instance NFData NetworkTag
+
+instance ToJSON NetworkTag where
+    toJSON (NetworkTag net) = Number (fromIntegral net)
 
 -- Describe requirements for address discrimination on the Byron era.
 data AddressDiscrimination

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -577,21 +577,6 @@ parseAddressInfoShelley AddressParts{..} = case addrType of
     unknown -> Left (UnknownType unknown)
 
   where
-    bytes  = unAddress addr
-    base16 = T.unpack . T.decodeUtf8 . encode EBase16
-
-    bech32With hrp = T.decodeUtf8 . encode (EBech32 hrp)
-    bech32Spending = bech32With CIP5.addr_vkh
-    bech32Stake = bech32With CIP5.stake_vkh
-    bech32Script = bech32With CIP5.script
-
-    ptrToJSON :: ChainPointer -> Json.Value
-    ptrToJSON ChainPointer{slotNum,transactionIndex,outputIndex} = Json.object
-        [ "slot_num" .= slotNum
-        , "transaction_index" .= transactionIndex
-        , "output_index" .= outputIndex
-        ]
-
     addressInfo = AddressInfo
         { infoNetworkTag = NetworkTag $ fromIntegral addrNetwork
         , infoStakeReference = Nothing
@@ -677,7 +662,8 @@ instance ToJSON AddressInfo where
         ++ maybe [] (\ptr -> ["pointer" .= ptr]) (infoStakeReference >>= getPointer)
         ++ jsonHash "spending_key_hash" CIP5.addr_vkh infoSpendingKeyHash
         ++ jsonHash "stake_key_hash" CIP5.stake_vkh infoStakeKeyHash
-        ++ jsonHash "script_hash" CIP5.script_vkh infoScriptHash
+        ++ jsonHash "spending_shared_hash" CIP5.addr_shared_vkh infoScriptHash
+        ++ jsonHash "stake_shared_hash" CIP5.stake_shared_vkh infoScriptHash
         ++ jsonHash "stake_script_hash" CIP5.stake_vkh infoStakeScriptHash
       where
         getPointer ByValue = Nothing

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -509,28 +509,27 @@ eitherInspectAddress mRootPub addr = unpackAddress addr >>= parseInfo
 parseAddressInfoShelley :: AddressParts -> Either ErrInspectAddressOnlyShelley AddressInfo
 parseAddressInfoShelley AddressParts{..} = case addrType of
     -- 0000: base address: keyhash28,keyhash28
-    -- fixme: 28 byte hashes ????
     0b00000000 | addrRestLength == credentialHashSize + credentialHashSize ->
         Right addressInfo
             { infoStakeReference = Just ByValue
             , infoSpendingKeyHash = Just addrHash1
             , infoStakeKeyHash = Just addrHash2
             }
-    -- 0001: base address: scripthash32,keyhash28
+    -- 0001: base address: scripthash28,keyhash28
     0b00010000 | addrRestLength == credentialHashSize + credentialHashSize ->
         Right addressInfo
             { infoStakeReference = Just ByValue
             , infoScriptHash = Just addrHash1
             , infoStakeKeyHash = Just addrHash2
             }
-    -- 0010: base address: keyhash28,scripthash32
+    -- 0010: base address: keyhash28,scripthash28
     0b00100000 | addrRestLength == credentialHashSize + credentialHashSize ->
         Right addressInfo
             { infoStakeReference = Just ByValue
             , infoSpendingKeyHash = Just addrHash1
             , infoStakeScriptHash = Just addrHash2
             }
-    -- 0011: base address: scripthash32,scripthash32
+    -- 0011: base address: scripthash28,scripthash28
     0b00110000 | addrRestLength == 2 * credentialHashSize ->
         Right addressInfo
             { infoStakeReference = Just ByValue
@@ -544,7 +543,7 @@ parseAddressInfoShelley AddressParts{..} = case addrType of
             { infoStakeReference = Just $ ByPointer ptr
             , infoSpendingKeyHash = Just addrHash1
             }
-    -- 0101: pointer address: scripthash32, 3 variable length uint
+    -- 0101: pointer address: scripthash28, 3 variable length uint
     0b01010000 | addrRestLength > credentialHashSize -> do
         ptr <- getPtr addrHash2
         pure addressInfo
@@ -557,7 +556,7 @@ parseAddressInfoShelley AddressParts{..} = case addrType of
             { infoStakeReference = Nothing
             , infoSpendingKeyHash = Just addrHash1
             }
-    -- 0111: enterprise address: scripthash32
+    -- 0111: enterprise address: scripthash28
     0b01110000 | addrRestLength == credentialHashSize ->
         Right addressInfo
             { infoStakeReference = Nothing
@@ -569,7 +568,7 @@ parseAddressInfoShelley AddressParts{..} = case addrType of
             { infoStakeReference = Just ByValue
             , infoStakeKeyHash = Just addrHash1
             }
-    -- 1111: reward account: scripthash32
+    -- 1111: reward account: scripthash28
     0b11110000 | addrRestLength == credentialHashSize ->
         Right addressInfo
             { infoStakeReference = Just ByValue

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,5 +1,5 @@
 name:                cardano-addresses
-version:             3.3.0
+version:             3.4.0
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK

--- a/jsbits/cardano-addresses-jsbits.cabal
+++ b/jsbits/cardano-addresses-jsbits.cabal
@@ -3,9 +3,11 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: d57abad013296a4fcf0ed769d4542afcaea883d8ca0ddd457778a4394f2cf136
 
 name:           cardano-addresses-jsbits
-version:        3.3.0
+version:        3.4.0
 synopsis:       Javascript code for ghcjs build of cardano-addresses.
 description:    This package supports ghcjs compilation of cardano-addresses with
                 Javascript wrappers and Emscripten builds of the cryptonite C

--- a/jsbits/package.yaml
+++ b/jsbits/package.yaml
@@ -1,5 +1,5 @@
 name:                cardano-addresses-jsbits
-version:             3.3.0
+version:             3.4.0
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK


### PR DESCRIPTION
### Issue

ADP-847

### Description

This doesn't change behaviour, but augments existing APIs with checked-exceptions variants.

Additionally, a record type is added for the `eitherInspectAddress` result value. There were some refactors necessary to accommodate this. The existing `inspectAddress` still produces a JSON value however.

The only API change is the error type constuctors.

### Comments

This should hopefully help and/or unblock @luite's work on the javascript wrapper.
