### PR TITLE
Add tests against CLI examples printed by cardano-addresses

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,11 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v1
 
+    - name: 💎 Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.1
+
     - name: 🧰 Setup Stack
       uses: mstksg/setup-stack@v1
 
@@ -43,6 +48,7 @@ jobs:
 
     - name: 🔨 Build & Test
       run: |
+        echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
         stack --no-terminal test --bench --haddock --no-haddock-deps --no-run-benchmarks --flag cardano-addresses:release --flag cardano-addresses-cli:release
         mkdir -p bin && cp $(stack path --local-install-root)/bin/* bin && chmod +x bin/*
         mkdir -p dist/haddock && mv $(stack path --local-install-root)/doc/* dist/haddock
@@ -52,6 +58,13 @@ jobs:
         DESTDIR=dist/coverage make report && DESTDIR=dist/coverage make badge
         echo "Checking for updated cabal files"
         git diff --exit-code -- '**/*.cabal' && echo OK
+
+    - name: 🧪 Test CLI examples
+      run: |
+        cd test/e2e
+        bundle install
+        rspec .
+        cd -
 
     - name: 📎 Upload Artifact
       uses: actions/upload-artifact@v1

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -16,6 +16,7 @@ mkShell rec {
     stack
     nix
     pkgconfig
+    bundler
   ] ++ lib.optional (!stdenv.isDarwin) git;
 
   libs = [

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,5 @@
+*.rspec_status
+*.prv
+*.pub
+*.xprv
+*.hash

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,5 +1,1 @@
 *.rspec_status
-*.prv
-*.pub
-*.xprv
-*.hash

--- a/test/e2e/.rspec
+++ b/test/e2e/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/test/e2e/Gemfile
+++ b/test/e2e/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rake', '~> 12.3'
+gem 'rspec'

--- a/test/e2e/Gemfile
+++ b/test/e2e/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'rake', '~> 12.3'
-gem 'rspec'
+gem 'rake', '12.3'
+gem 'rspec', '3.10.0'

--- a/test/e2e/Gemfile.lock
+++ b/test/e2e/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.4.4)
+    rake (12.3.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake (~> 12.3)
+  rspec
+
+BUNDLED WITH
+   2.1.4

--- a/test/e2e/Gemfile.lock
+++ b/test/e2e/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
-    rake (12.3.3)
+    rake (12.3.0)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -21,8 +21,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake (~> 12.3)
-  rspec
+  rake (= 12.3)
+  rspec (= 3.10.0)
 
 BUNDLED WITH
    2.1.4

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,12 @@
+## How to use rspec e2e tests
+
+Install dependencies and run tests:
+
+```terminal
+$ bundle install
+$ PATH=$bin_path:$PATH bundle exec rspec
+```
+
+It needs `cardano-address` in the `$PATH`, so set your `$bin_path`
+variable to the relevant build directory from `.stack-work` or
+`dist-newstyle`.

--- a/test/e2e/helpers/matchers.rb
+++ b/test/e2e/helpers/matchers.rb
@@ -1,0 +1,25 @@
+require "rspec/expectations"
+
+RSpec::Matchers.define :succeed do
+    match do |out_arr|
+      out_arr[2].success? == true
+    end
+    failure_message do |out_arr|
+      out = out_arr[0]
+      err = out_arr[1]
+      cmd = out_arr[3]
+      %(
+        Following command failed!!!
+        --------------------------------------------
+        #{cmd}
+
+        StdErr:
+        --------------------------------------------
+        #{err}
+
+        StdOut:
+        --------------------------------------------
+        #{out}
+      )
+    end
+  end

--- a/test/e2e/spec/examples_spec.rb
+++ b/test/e2e/spec/examples_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe "CLI examples" do
   end
 
   it "cardano-address key" do
-    pending "<<< operator is not supprted by shell"
     o, e = ca_cmd('key')
     examples = get_examples(e)
     examples.each do |example|

--- a/test/e2e/spec/examples_spec.rb
+++ b/test/e2e/spec/examples_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe "CLI examples" do
+
+  it "cardano-address address payment" do
+    o, e = ca_cmd('address', 'payment')
+    examples = get_examples(e)
+    examples.each do |ex_cmd|
+      expect(cmd(ex_cmd)).to succeed
+    end
+  end
+
+  it "cardano-address address bootstrap" do
+    o, e = ca_cmd('address', 'bootstrap')
+    examples = get_examples(e)
+    examples.each do |ex_cmd|
+      expect(cmd(ex_cmd)).to succeed
+    end
+  end
+
+  it "cardano-address address stake" do
+    o, e = ca_cmd('address', 'stake')
+    examples = get_examples(e)
+    examples.each do |ex_cmd|
+      expect(cmd(ex_cmd)).to succeed
+    end
+  end
+
+  it "cardano-address address delegation" do
+    o, e = ca_cmd('address', 'delegation')
+    examples = get_examples(e)
+    examples.each do |ex_cmd|
+      expect(cmd(ex_cmd)).to succeed
+    end
+  end
+
+  it "cardano-address address pointer" do
+    o, e = ca_cmd('address', 'pointer')
+    examples = get_examples(e)
+    examples.each do |ex_cmd|
+      expect(cmd(ex_cmd)).to succeed
+    end
+  end
+
+  it "cardano-address script" do
+    o, e = ca_cmd('script')
+    examples = get_examples(e)
+    examples.each do |ex_cmd|
+      expect(cmd(ex_cmd)).to succeed
+    end
+  end
+
+  it "cardano-address key" do
+    pending "<<< operator is not supprted by shell"
+    o, e = ca_cmd('key')
+    examples = get_examples(e)
+    examples.each do |ex_cmd|
+      expect(cmd(ex_cmd)).to succeed
+    end
+  end
+
+end

--- a/test/e2e/spec/examples_spec.rb
+++ b/test/e2e/spec/examples_spec.rb
@@ -1,59 +1,38 @@
 RSpec.describe "CLI examples" do
 
   it "cardano-address address payment" do
-    o, e = ca_cmd('address', 'payment')
-    examples = get_examples(e)
-    examples.each do |example|
-      expect(cmd(example)).to succeed
-    end
+    examples = get_examples('address', 'payment')
+    run_examples(examples)
   end
 
   it "cardano-address address bootstrap" do
-    o, e = ca_cmd('address', 'bootstrap')
-    examples = get_examples(e)
-    examples.each do |example|
-      expect(cmd(example)).to succeed
-    end
+    examples = get_examples('address', 'bootstrap')
+    run_examples(examples)
   end
 
   it "cardano-address address stake" do
-    o, e = ca_cmd('address', 'stake')
-    examples = get_examples(e)
-    examples.each do |example|
-      expect(cmd(example)).to succeed
-    end
+    examples = get_examples('address', 'stake')
+    run_examples(examples)
   end
 
   it "cardano-address address delegation" do
-    o, e = ca_cmd('address', 'delegation')
-    examples = get_examples(e)
-    examples.each do |example|
-      expect(cmd(example)).to succeed
-    end
+    examples = get_examples('address', 'delegation')
+    run_examples(examples)
   end
 
   it "cardano-address address pointer" do
-    o, e = ca_cmd('address', 'pointer')
-    examples = get_examples(e)
-    examples.each do |example|
-      expect(cmd(example)).to succeed
-    end
+    examples = get_examples('address', 'pointer')
+    run_examples(examples)
   end
 
   it "cardano-address script" do
-    o, e = ca_cmd('script')
-    examples = get_examples(e)
-    examples.each do |example|
-      expect(cmd(example)).to succeed
-    end
+    examples = get_examples('script')
+    run_examples(examples)
   end
 
   it "cardano-address key" do
-    o, e = ca_cmd('key')
-    examples = get_examples(e)
-    examples.each do |example|
-      expect(cmd(example)).to succeed
-    end
+    examples = get_examples('key')
+    run_examples(examples)
   end
 
 end

--- a/test/e2e/spec/examples_spec.rb
+++ b/test/e2e/spec/examples_spec.rb
@@ -3,48 +3,48 @@ RSpec.describe "CLI examples" do
   it "cardano-address address payment" do
     o, e = ca_cmd('address', 'payment')
     examples = get_examples(e)
-    examples.each do |ex_cmd|
-      expect(cmd(ex_cmd)).to succeed
+    examples.each do |example|
+      expect(cmd(example)).to succeed
     end
   end
 
   it "cardano-address address bootstrap" do
     o, e = ca_cmd('address', 'bootstrap')
     examples = get_examples(e)
-    examples.each do |ex_cmd|
-      expect(cmd(ex_cmd)).to succeed
+    examples.each do |example|
+      expect(cmd(example)).to succeed
     end
   end
 
   it "cardano-address address stake" do
     o, e = ca_cmd('address', 'stake')
     examples = get_examples(e)
-    examples.each do |ex_cmd|
-      expect(cmd(ex_cmd)).to succeed
+    examples.each do |example|
+      expect(cmd(example)).to succeed
     end
   end
 
   it "cardano-address address delegation" do
     o, e = ca_cmd('address', 'delegation')
     examples = get_examples(e)
-    examples.each do |ex_cmd|
-      expect(cmd(ex_cmd)).to succeed
+    examples.each do |example|
+      expect(cmd(example)).to succeed
     end
   end
 
   it "cardano-address address pointer" do
     o, e = ca_cmd('address', 'pointer')
     examples = get_examples(e)
-    examples.each do |ex_cmd|
-      expect(cmd(ex_cmd)).to succeed
+    examples.each do |example|
+      expect(cmd(example)).to succeed
     end
   end
 
   it "cardano-address script" do
     o, e = ca_cmd('script')
     examples = get_examples(e)
-    examples.each do |ex_cmd|
-      expect(cmd(ex_cmd)).to succeed
+    examples.each do |example|
+      expect(cmd(example)).to succeed
     end
   end
 
@@ -52,8 +52,8 @@ RSpec.describe "CLI examples" do
     pending "<<< operator is not supprted by shell"
     o, e = ca_cmd('key')
     examples = get_examples(e)
-    examples.each do |ex_cmd|
-      expect(cmd(ex_cmd)).to succeed
+    examples.each do |example|
+      expect(cmd(example)).to succeed
     end
   end
 

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -1,0 +1,43 @@
+require 'bundler/setup'
+require 'open3'
+require_relative '../helpers/matchers'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end
+
+
+# Helpers
+def cmd(cmd)
+  out, err, status = Open3.capture3(cmd)
+  return [out, err, status, cmd]
+end
+
+def ca_cmd(*args)
+  cmd("cardano-address #{args.join(' ')}")
+end
+
+def get_examples(output)
+  # get examples
+  cmds = output.partition('Example:').last.split(" \n ")
+
+  # remove outputs
+  cmds = cmds.map {|c| c[0, c.rindex("\e[0m\n")]}
+
+  # clean up
+  cmds = cmds.map {|c| c.gsub("\e[1m", '') }.
+              map {|c| c.gsub("\e[0m", '') }.
+              map {|c| c.gsub("\n", '') }.
+              map {|c| c.gsub("\\", '') }.
+              map {|c| c[c.index("$") + 1, c.size] }. # remove starting $
+              map {|c| c.strip }
+  cmds
+end

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -14,7 +14,6 @@ RSpec.configure do |config|
   end
 end
 
-
 # Helpers
 def cmd(cmd)
   out, err, status = Open3.capture3(cmd)

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -16,7 +16,8 @@ end
 
 # Helpers
 def cmd(cmd)
-  out, err, status = Open3.capture3(cmd)
+  # running commands against bash because not all are compatible with shell
+  out, err, status = Open3.capture3("bash -c #{cmd}")
   return [out, err, status, cmd]
 end
 


### PR DESCRIPTION
**Motivation:** https://github.com/input-output-hk/cardano-addresses/pull/119#issuecomment-816455977

**Context:**
Every now and then we encounter that CLI example printed by `cardano-address` is out of date and needs to be fixed (like https://github.com/input-output-hk/cardano-addresses/pull/119). I thought it might be good idea to test those examples in kind of end-to-end fashion. This little test suite gets all the examples from the CLI and runs them making sure each command succeeds. 

**Output:**

```
$ rspec

CLI examples
  cardano-address address payment
  cardano-address address bootstrap
  cardano-address address stake
  cardano-address address delegation
  cardano-address address pointer
  cardano-address script
  cardano-address key

Finished in 0.15025 seconds (files took 0.22205 seconds to load)
7 examples, 0 failures
```

Clear message in case of error:

```
     Failure/Error: expect(cmd(ex_cmd)).to succeed
     
               Following command failed!!!
               --------------------------------------------
               cardano-address key inspect <<< $(cat acct.prv)
     
               StdErr:
               --------------------------------------------
               sh: 1: Syntax error: redirection unexpected
     
     
               StdOut:
               --------------------------------------------

```

**TODO:**
 - ~wire into GH actions~ https://github.com/input-output-hk/cardano-addresses/pull/122/checks?check_run_id=2308362484
 - ~check if it works on Windows~ - it doesn't. Examples are not tailored for Windows cmd (there's `cat`, `tee`, `<<<` which are not available on Win)
 - ~I'm having some problems with examples from `cardano-address key` subcommand. The examples use `<<<` which seems not to be supported by shell (I suppose only bash supports it) - try to fix it.~
