### PR TITLE
Update to GHC 8.10

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,6 @@
 index-state: 2021-03-23T15:08:40Z
 
--- NOTE: Staying on 8.6.5 to match stack.yaml and also because ghcjs
--- does not yet support 8.10.4.
-with-compiler: ghc-8.6.5
+with-compiler: ghc-8.10.4
 
 packages:
   command-line/cardano-addresses-cli.cabal
@@ -31,7 +29,13 @@ source-repository-package
 
 -- Relax overly strict bounds in hjsonschema and hjsonpointer
 allow-newer:
-    hjsonschema:*
-  , hjsonpointer:*
+    hjsonschema:QuickCheck
+  , hjsonschema:aeson
+  , hjsonschema:hashable
+  , hjsonschema:hjsonpointer
+  , hjsonschema:protolude
+  , hjsonpointer:aeson
+  , hjsonpointer:hashable
+  , stm:base
 
 test-show-details: direct

--- a/jsbits/emscripten/crypto-wrappers.js
+++ b/jsbits/emscripten/crypto-wrappers.js
@@ -273,9 +273,9 @@ function h$cryptonite_ed25519_scalar_decode_long(out_d, out_o, in_d, in_o, len) 
   h$logWrapper("h$cardano_crypto_ed25519_decode_long");
   // XXX sizes
   var in_ptr = h$getTmpBufferWith(0, in_d, in_o, len),
-      out_ptr = h$getTmpBuffer(1, 32);
+      out_ptr = h$getTmpBuffer(1, 40);
   var r = h$cardano_crypto._cryptonite_ed25519_scalar_decode_long(out_ptr, in_ptr, len);
-  h$copyFromHeap(out_ptr, out_d, out_o, 32);
+  h$copyFromHeap(out_ptr, out_d, out_o, 40);
   return r;
 }
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -133,12 +133,14 @@ let
         packages.digest.components.library.libs = lib.mkForce [ pkgs.buildPackages.zlib ];
         packages.cardano-addresses-cli.components.library.build-tools = [ pkgs.buildPackages.buildPackages.gitMinimal ];
         packages.cardano-addresses-jsbits.components.library.preConfigure = addJsbits;
-
         # Disable CLI running tests under ghcjs
         packages.cardano-addresses-cli.components.tests.unit.preCheck = ''
-          echo "CLI tests disabled under ghcjs"
-          exit 0
+          export CARDANO_ADDRESSES_CLI="${config.hsPkgs.cardano-addresses-cli.components.exes.cardano-address}/bin"
         '';
+        packages.cardano-addresses-cli.components.tests.unit.build-tools = pkgs.lib.mkForce [
+          config.hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover
+          pkgs.buildPackages.nodejs
+        ];
       })
     ];
   });

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -54,8 +54,8 @@ let
         ];
       })
       ({ config, ... }: {
-        packages.cardano-addresses.configureFlags = [ "--ghc-option=-Werror" ];
-        packages.cardano-addresses-cli.configureFlags = [ "--ghc-option=-Werror" ];
+        # packages.cardano-addresses.configureFlags = [ "--ghc-option=-Werror" ];
+        # packages.cardano-addresses-cli.configureFlags = [ "--ghc-option=-Werror" ];
 
         # This works around an issue with `cardano-addresses-cli.cabal`
         # Haskell.nix does not like `build-tool: cardano-address` as it looks in the

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -67,7 +67,7 @@ let
         # `build-tool-depends` is used.
         packages.cardano-addresses-cli.components.tests.unit.build-tools = pkgs.lib.mkForce [
           config.hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover
-          config.hsPkgs.buildPackages.cardano-addresses-cli.components.exes.cardano-address
+          config.hsPkgs.cardano-addresses-cli.components.exes.cardano-address
         ];
       })
 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,7 +1,7 @@
 # our packages overlay
 pkgs: _: with pkgs;
   let
-    compiler = config.haskellNix.compiler or "ghc865";
+    compiler = config.haskellNix.compiler or "ghc8104";
   in {
   cardanoAddressesHaskellPackages = import ./haskell.nix {
     inherit compiler

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "87084d65a476cc826a0e8c5d281d494254f5bc7a",
-        "sha256": "168vj5zswhxvvgp39ksr400gl2szih9sjbcdz2wsb7r7rnwp42xp",
+        "rev": "542670ef5551d5c28f156646c161bca242c4fee2",
+        "sha256": "0p9qjpd42xzzwmrskfnz2qvh1gywnsipzpckz1s43690lyr2qiww",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/87084d65a476cc826a0e8c5d281d494254f5bc7a.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/542670ef5551d5c28f156646c161bca242c4fee2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "1124e4d220aefa13dacac3c132d8b6746f9026da",
-        "sha256": "0zib3f6g2dk0azks46267blp1ami6sivr8kspfwcpyhl8iq11qvf",
+        "rev": "87084d65a476cc826a0e8c5d281d494254f5bc7a",
+        "sha256": "168vj5zswhxvvgp39ksr400gl2szih9sjbcdz2wsb7r7rnwp42xp",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/1124e4d220aefa13dacac3c132d8b6746f9026da.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/87084d65a476cc826a0e8c5d281d494254f5bc7a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/release.nix
+++ b/release.nix
@@ -77,14 +77,12 @@ let
     ghcjs = mapTestOnCross ghcjs (packagePlatformsCross (filterJobsCross project));
   } // (mkRequiredJob (concatLists [
     (collectJobs jobs.musl64.checks)
-    # fixme: mingw32 cross builds broken with ghc-8.6.5
-    # (collectJobs jobs."${mingwW64.config}".checks)
+    (collectJobs jobs."${mingwW64.config}".checks)
     (collectJobs jobs.ghcjs.checks)
     [ jobs.native.shell.x86_64-linux
       jobs.native.shell.x86_64-darwin
       jobs.musl64.cardano-address.x86_64-linux
-      # fixme: mingw32 cross builds broken with ghc-8.6.5
-      # jobs."${mingwW64.config}".cardano-address.x86_64-linux
+      jobs."${mingwW64.config}".cardano-address.x86_64-linux
       jobs.ghcjs.library.x86_64-linux
     ]
   ]));

--- a/release.nix
+++ b/release.nix
@@ -71,7 +71,7 @@ let
   inherit (systems.examples) mingwW64 musl64 ghcjs;
 
   jobs = {
-    native = mapTestOn (recursiveUpdate (packagePlatforms project) { checks = []; });
+    native = mapTestOn (packagePlatforms project);
     "${mingwW64.config}" = recursiveUpdate (mapTestOnCross mingwW64 (packagePlatformsCross (filterJobsCross project))) disabledMingwW64Tests;
     musl64 = mapTestOnCross musl64 (packagePlatformsCross (filterJobsCross project));
     ghcjs = mapTestOnCross ghcjs (packagePlatformsCross (filterJobsCross project));


### PR DESCRIPTION
### Ticket

### Overview

Update ghc and ghcjs to 8.10.x.

This should fix the windows cross build and let us drop ghc-8.6.5 support.

### Comments

[Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-addresses-pr-127)
