### PR TITLE
Move jsbits from cabal.project to nix cabalProjectLocal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,6 +31,7 @@ source-repository-package
 
 -- Relax overly strict bounds in hjsonschema and hjsonpointer
 allow-newer:
-    hjsonschema:aeson
-  , hjsonschema:hjsonpointer
-  , hjsonpointer:aeson
+    hjsonschema:*
+  , hjsonpointer:*
+
+test-show-details: direct

--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,6 @@ with-compiler: ghc-8.6.5
 packages:
   command-line/cardano-addresses-cli.cabal
   core/cardano-addresses.cabal
-  jsbits/cardano-addresses-jsbits.cabal
 
 -- Needed for ghcjs
 -- See https://github.com/haskell-crypto/cryptonite/pull/345

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2021-03-23T15:14:00Z
+index-state: 2021-03-23T15:08:40Z
 
 -- NOTE: Staying on 8.6.5 to match stack.yaml and also because ghcjs
 -- does not yet support 8.10.4.

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 946bc4e2822bf83d73f3bc5c368a9bba6498c9d6fb9cc53b6a92ac5eb2f11684
+-- hash: f380e56b6b727ea7067da62533485612742dbbe2d3b2d12b134e7c8b0ed87253
 
 name:           cardano-addresses-cli
 version:        3.3.0
@@ -146,7 +146,7 @@ test-suite unit
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      QuickCheck
+      QuickCheck >=2.14.2
     , aeson
     , base >=4.7 && <5
     , bech32

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f9dae3519ee875de20289c2073fb6bb3f7cd290369f08095b90b3c4a976e4edf
+-- hash: 946bc4e2822bf83d73f3bc5c368a9bba6498c9d6fb9cc53b6a92ac5eb2f11684
 
 name:           cardano-addresses-cli
 version:        3.3.0
@@ -100,8 +100,8 @@ executable cardano-address
   ghc-options: -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , cardano-addresses
     , cardano-addresses-cli
-    , cardano-addresses-jsbits
   if flag(release) && !impl(ghcjs) && !os(ghcjs)
     ghc-options: -Werror -static -O2
     cc-options: -static
@@ -154,7 +154,6 @@ test-suite unit
     , bytestring
     , cardano-addresses
     , cardano-addresses-cli
-    , cardano-addresses-jsbits
     , containers
     , hspec
     , process

--- a/command-line/exe/Main.hs
+++ b/command-line/exe/Main.hs
@@ -4,8 +4,8 @@ module Main where
 
 import Prelude
 
-import Cardano.Address.Jsbits
-    ( addJsbitsDependency )
+import Cardano.Address.Compat
+    ( ghcjsBuildSupport )
 import Command
     ( withUtf8Encoding )
 
@@ -13,5 +13,5 @@ import qualified Command as CLI
 
 main :: IO ()
 main = do
-    addJsbitsDependency
+    ghcjsBuildSupport
     withUtf8Encoding (CLI.setup >> CLI.parse >>= CLI.run)

--- a/command-line/package.yaml
+++ b/command-line/package.yaml
@@ -65,9 +65,8 @@ executables:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
+    - cardano-addresses
     - cardano-addresses-cli
-    # TODO remove once js-sources from cardano-addresses-jsbits works correctly
-    - cardano-addresses-jsbits
     when:
     - condition: 'flag(release) && !impl(ghcjs) && !os(ghcjs)'
       ghc-options:
@@ -108,7 +107,6 @@ tests:
     - bytestring
     - cardano-addresses
     - cardano-addresses-cli
-    - cardano-addresses-jsbits
     - containers
     - hspec
     - process

--- a/command-line/package.yaml
+++ b/command-line/package.yaml
@@ -110,7 +110,7 @@ tests:
     - containers
     - hspec
     - process
-    - QuickCheck
+    - QuickCheck >= 2.14.2
     - string-interpolate
     - temporary
     - text

--- a/command-line/test/Main.hs
+++ b/command-line/test/Main.hs
@@ -2,8 +2,8 @@ module Main where
 
 import Prelude
 
-import Cardano.Address.Jsbits
-    ( addJsbitsDependency )
+import Cardano.Address.Compat
+    ( ghcjsBuildSupport )
 import Command
     ( withUtf8Encoding )
 import Test.Hspec.Runner
@@ -11,8 +11,7 @@ import Test.Hspec.Runner
 
 import qualified AutoDiscover
 
-
 main :: IO ()
 main = do
-    addJsbitsDependency
+    ghcjsBuildSupport
     withUtf8Encoding $ hspecWith defaultConfig AutoDiscover.spec

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 11dd066f96bb160ea0e0895fbe57d33aeffa695cd8fc32808fa23aab2284d1ca
+-- hash: 71852429d7ba72f91641d49069aa9bf80667626b706945067fd0f4ae3158862b
 
 name:           cardano-addresses
 version:        3.3.0
@@ -31,6 +31,7 @@ flag release
 library
   exposed-modules:
       Cardano.Address
+      Cardano.Address.Compat
       Cardano.Address.Derivation
       Cardano.Address.Script
       Cardano.Address.Script.Parser
@@ -58,7 +59,6 @@ library
     , bech32-th
     , binary
     , bytestring
-    , cardano-addresses-jsbits
     , cardano-crypto
     , cborg
     , containers
@@ -74,6 +74,9 @@ library
     , unordered-containers
   if flag(release)
     ghc-options: -Werror
+  if impl(ghcjs) || os(ghcjs)
+    build-depends:
+        cardano-addresses-jsbits
   default-language: Haskell2010
 
 test-suite unit
@@ -110,7 +113,6 @@ test-suite unit
     , binary
     , bytestring
     , cardano-addresses
-    , cardano-addresses-jsbits
     , cardano-crypto
     , containers
     , hspec

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 71852429d7ba72f91641d49069aa9bf80667626b706945067fd0f4ae3158862b
+-- hash: ed1f4406910ece0166a2df56354db7c2a3f027832734cb9791454d3a87b3421c
 
 name:           cardano-addresses
 version:        3.3.0
@@ -105,7 +105,7 @@ test-suite unit
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      QuickCheck
+      QuickCheck >=2.14.2
     , aeson
     , aeson-pretty
     , base >=4.7 && <5

--- a/core/lib/Cardano/Address/Compat.hs
+++ b/core/lib/Cardano/Address/Compat.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP #-}
+
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+-- A compatibility function for the GHCJS build.
+
+module Cardano.Address.Compat
+    ( ghcjsBuildSupport
+    ) where
+
+import Prelude
+
+#ifdef ghcjs_HOST_OS
+import Cardano.Address.Jsbits
+    ( addJsbitsDependency )
+#endif
+
+-- | This function must be used somewhere, so that external Javascript files are
+-- correctly linked in the GHCJS build.
+--
+-- For non-GHCJS, it has no effect.
+ghcjsBuildSupport :: IO ()
+#ifdef ghcjs_HOST_OS
+ghcjsBuildSupport = addJsbitsDependency
+#else
+ghcjsBuildSupport = pure ()
+#endif

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -30,6 +30,10 @@ library:
   - condition: flag(release)
     ghc-options:
     - -Werror
+  - condition: impl(ghcjs) || os(ghcjs)
+    dependencies:
+    # TODO remove once js-sources from cardano-addresses-jsbits works correctly
+    - cardano-addresses-jsbits
   default-extensions:
   - NoImplicitPrelude
   dependencies:
@@ -40,7 +44,6 @@ library:
   - bech32-th
   - binary
   - bytestring
-  - cardano-addresses-jsbits
   - cardano-crypto
   - cborg
   - containers
@@ -80,7 +83,6 @@ tests:
     - binary
     - bytestring
     - cardano-addresses
-    - cardano-addresses-jsbits
     - cardano-crypto
     - containers
     - hspec

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -87,7 +87,7 @@ tests:
     - containers
     - hspec
     - memory
-    - QuickCheck
+    - QuickCheck >= 2.14.2
     - text
     - hspec-golden >= 0.1.0.3 && < 0.2
     - pretty-simple

--- a/core/test/Main.hs
+++ b/core/test/Main.hs
@@ -2,8 +2,8 @@ module Main where
 
 import Prelude
 
-import Cardano.Address.Jsbits
-    ( addJsbitsDependency )
+import Cardano.Address.Compat
+    ( ghcjsBuildSupport )
 import Test.Hspec.Runner
     ( defaultConfig, hspecWith )
 
@@ -11,5 +11,5 @@ import qualified AutoDiscover
 
 main :: IO ()
 main = do
-    addJsbitsDependency
+    ghcjsBuildSupport
     hspecWith defaultConfig AutoDiscover.spec

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -72,13 +72,18 @@ let
       })
 
       # Build fixes for Hackage dependencies.
-      {
+      ({ pkgs, ...}: let
+        pcre = pkgs.pcre.overrideAttrs (oldAttrs: {
+          configureFlags = oldAttrs.configureFlags ++ [ "--enable-static" ];
+        });
+      in {
         # Needed for linking of the musl static build.
         packages.pcre-light.flags.use-pkg-config = true;
+        packages.pcre-light.components.library.libs = [ pcre ];
         packages.cardano-addresses-cli.components.tests.unit.configureFlags =
           lib.mkIf stdenv.hostPlatform.isMusl
-            [ "--ghc-option=-optl=-L${pkgs.pcre}/lib" ];
-      }
+            [ "--ghc-option=-optl=-L${pcre}/lib" ];
+      })
 
       (lib.mkIf isCrossBuild {
         # Remove hsc2hs build-tool dependencies (suitable version will

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -26,7 +26,10 @@ let
     # FIXME: without this deprecated attribute, db-converter fails to compile directory with:
   } // {
     # Constraints not in `cabal.project.freeze for cross platform support
-    cabalProjectLocal = lib.optionalString stdenv.hostPlatform.isWindows ''
+    cabalProjectLocal = ''
+      packages:
+        jsbits/cardano-addresses-jsbits.cabal
+    '' + lib.optionalString stdenv.hostPlatform.isWindows ''
       constraints: Wind32 ==2.6.1.0, mintty ==0.1.2
     '';
 


### PR DESCRIPTION
This prevents the `cabal` from attempting to build the package inside the nix shell (instead the version provided by the nix shell will be used).

This prevents errors like:

```
[nix-shell:~/iohk/cardano-addresses]$ js-unknown-ghcjs-cabal run cardano-addresses:test:unit
Warning: don't know how to find change monitoring files for the installed
package databases for ghcjs
Warning: Requested index-state 2021-03-23T15:14:00Z is newer than
'hackage.haskell.org'! Falling back to older state (2021-03-23T15:08:40Z).
Resolving dependencies...
Build profile: -w ghcjs-8.10.4 -O1
In order, the following will be built (use -v for more details):
 - cardano-addresses-jsbits-3.3.0 (lib) (first run)
 - cardano-addresses-3.3.0 (lib) (configuration changed)
 - cardano-addresses-3.3.0 (test:unit) (configuration changed)
Configuring library for cardano-addresses-jsbits-3.3.0..
Preprocessing library for cardano-addresses-jsbits-3.3.0..
Building library for cardano-addresses-jsbits-3.3.0..
[1 of 1] Compiling Cardano.Address.Jsbits ( lib/Cardano/Address/Jsbits.hs, /home/hamish/iohk/cardano-addresses/dist-newstyle/build/js-ghcjs/ghcjs-8.10.4/cardano-addresses-jsbits-3.3.0/build/Cardano/Address/Jsbits.js_o )
jsbits/cardano-crypto.js: openBinaryFile: does not exist (No such file or directory)
cabal: Failed to build cardano-addresses-jsbits-3.3.0 (which is required by
test:unit from cardano-addresses-3.3.0).
```

The only drawback is that if we need to use `cabal` to build with ghc outside of a nix-shell it will need a modified `cabal.project` file or `cabal.project.local` file added.