### PR TITLE
Silence new warnings from GHC 8.10

### DIFF
--- a/command-line/lib/Options/Applicative/Discrimination.hs
+++ b/command-line/lib/Options/Applicative/Discrimination.hs
@@ -19,8 +19,6 @@ import Cardano.Address
     ( NetworkDiscriminant (..), NetworkTag (..) )
 import Cardano.Address.Style.Shelley
     ( Shelley )
-import Control.Monad.Fail
-    ( MonadFail )
 import Data.List
     ( intercalate )
 import Options.Applicative

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 544d2e87cc39554e8ef1cf9ed0304a90282254ca43c254e70eb705a079653923
+-- hash: bd8548f62cb3cd204176970099aa6a614afd2ea3785adff19770e8b2b768b4e9
 
 name:           cardano-addresses
 version:        3.4.0

--- a/core/lib/Cardano/Address.hs
+++ b/core/lib/Cardano/Address.hs
@@ -59,6 +59,8 @@ import Data.ByteString
     ( ByteString )
 import Data.Either.Extra
     ( eitherToMaybe )
+import Data.Kind
+    ( Type )
 import Data.Text
     ( Text )
 import Data.Word
@@ -219,8 +221,8 @@ class PaymentAddress key
             -- ^ Pointer to locate delegation key in blockchain
         -> Address
 
-class HasNetworkDiscriminant (key :: Depth -> * -> *) where
-    type NetworkDiscriminant key :: *
+class HasNetworkDiscriminant (key :: Depth -> Type -> Type) where
+    type NetworkDiscriminant key :: Type
 
     addressDiscrimination :: NetworkDiscriminant key -> AddressDiscrimination
     networkTag :: NetworkDiscriminant key -> NetworkTag

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -87,6 +87,8 @@ import Data.Coerce
     ( coerce )
 import Data.Either.Extra
     ( eitherToMaybe )
+import Data.Kind
+    ( Type )
 import Data.String
     ( fromString )
 import Data.Word
@@ -402,10 +404,10 @@ data DerivationType = Hardened | Soft | WholeDomain
 -- | An interface for doing hard derivations from the root private key, /Master Key/
 --
 -- @since 1.0.0
-class HardDerivation (key :: Depth -> * -> *) where
+class HardDerivation (key :: Depth -> Type -> Type) where
     type AccountIndexDerivationType key :: DerivationType
     type AddressIndexDerivationType key :: DerivationType
-    type WithRole key :: *
+    type WithRole key :: Type
 
     -- | Derives account private key from the given root private key, using
     -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
@@ -429,7 +431,7 @@ class HardDerivation (key :: Depth -> * -> *) where
         -> key 'PaymentK XPrv
 
 -- | An interface for doing soft derivations from an account public key
-class HardDerivation key => SoftDerivation (key :: Depth -> * -> *) where
+class HardDerivation key => SoftDerivation (key :: Depth -> Type -> Type) where
     -- | Derives address public key from the given account public key, using
     -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
     -- package for more details).
@@ -447,8 +449,8 @@ class HardDerivation key => SoftDerivation (key :: Depth -> * -> *) where
 -- | Abstract interface for constructing a /Master Key/.
 --
 -- @since 1.0.0
-class GenMasterKey (key :: Depth -> * -> *) where
-    type SecondFactor key :: *
+class GenMasterKey (key :: Depth -> Type -> Type) where
+    type SecondFactor key :: Type
 
     -- | Generate a root key from a corresponding mnemonic.
     --

--- a/core/lib/Cardano/Address/Script.hs
+++ b/core/lib/Cardano/Address/Script.hs
@@ -84,6 +84,8 @@ import Data.Foldable
     ( asum, foldl', traverse_ )
 import Data.Functor.Identity
     ( Identity (..) )
+import Data.Kind
+    ( Type )
 import Data.Map.Strict
     ( Map )
 import Data.Set
@@ -117,7 +119,7 @@ import qualified Data.Text.Read as T
 -- that need to be satisfied to make it valid.
 --
 -- @since 3.0.0
-data Script (elem :: *)
+data Script (elem :: Type)
     = RequireSignatureOf !elem
     | RequireAllOf ![Script elem]
     | RequireAnyOf ![Script elem]

--- a/core/lib/Cardano/Address/Style/Byron.hs
+++ b/core/lib/Cardano/Address/Style/Byron.hs
@@ -110,6 +110,8 @@ import Data.ByteArray
     ( ScrubbedBytes )
 import Data.ByteString
     ( ByteString )
+import Data.Kind
+    ( Type )
 import Data.List
     ( find )
 import Data.Word
@@ -182,7 +184,7 @@ deriving instance (Functor (Byron depth))
 -- | The hierarchical derivation indices for a given level/depth.
 --
 -- @since 1.0.0
-type family DerivationPath (depth :: Depth) :: * where
+type family DerivationPath (depth :: Depth) :: Type where
     -- The root key is generated from the seed.
     DerivationPath 'RootK =
         ()

--- a/core/lib/Cardano/Codec/Cbor.hs
+++ b/core/lib/Cardano/Codec/Cbor.hs
@@ -49,8 +49,6 @@ import Control.Monad
     ( replicateM, when )
 import Control.Monad.Catch
     ( MonadThrow, throwM )
-import Control.Monad.Fail
-    ( MonadFail )
 import Crypto.Error
     ( CryptoError (..), CryptoFailable (..) )
 import Crypto.Hash
@@ -417,4 +415,3 @@ unsafeDeserialiseCbor decoder bytes = either
     (\e -> error $ "unsafeSerializeCbor: " <> show e)
     snd
     (CBOR.deserialiseFromBytes decoder bytes)
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.25
+resolver: lts-17.12
 
 packages:
 - core


### PR DESCRIPTION
Updates the stack/CI build to use LTS Haskell 17.12 (ghc-8.10.4) and address warning messages from GHC.
