### PR TITLE
remove deprecated ALLOW_TAG_PREFIX from release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,6 @@ jobs:
         PRE_RELEASE: "false"
         CHANGELOG_FILE: "ChangeLog.md"
         ALLOW_EMPTY_CHANGELOG: "false"
-        ALLOW_TAG_PREFIX: "true"
       with:
         args: |
           ${{ steps.variables.outputs.pkg_name }}-${{ steps.variables.outputs.tag }}-linux64.tar.gz


### PR DESCRIPTION
It seems it is deprecated (https://github.com/input-output-hk/cardano-addresses/runs/2911314075?check_suite_focus=true).
I'm not sure if we need it at all so removing all together.

If needed, then can be replaced by something like `TAG_PREFIX_REGEX: [a-z-]*` as per https://github.com/anton-yurchenko/git-release#configuration.