### PR TITLE
Fixing Docker build. Fixes #137

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY stack.yaml .
 RUN mkdir -p command-line core
 COPY core/package.yaml core/package.yaml
 COPY command-line/package.yaml command-line/package.yaml
+ADD jsbits /build/jsbits
 RUN stack setup
 RUN stack build --only-snapshot
 RUN stack build --only-dependencies
@@ -25,7 +26,7 @@ RUN stack install --flag cardano-addresses:release
 #                                                                              #
 
 FROM frolvlad/alpine-glibc:alpine-3.11_glibc-2.30
-RUN apk add --no-cache gmp=6.1.2-r1 bash=5.0.11-r1 bash-completion=2.9-r0
+RUN apk add --no-cache gmp=6.1.2-r1 bash=5.0.11-r1 bash-completion=2.9-r0 libstdc++=9.3.0-r0
 COPY --from=build /root/.local/bin /bin
 RUN mkdir /etc/bash_completion.d
 RUN cardano-address --bash-completion-script `which cardano-address` > /etc/bash_completion.d/cardano-address


### PR DESCRIPTION
I was unable to compile this project via docker by following the steps in the readme due to the `jsbits` dir not being accessible from the container.

Later on, after fixing that issue, I was also unable to run the project inside docker due to the lack of `libstdc++`. This fixed both of the issues for me.