### PR TITLE
Export `ReferenceInfo`

### DIFF
--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 03610515aab4ce0646ae009958bf00b96cc73121dc3d6a1fa5ca8aa276dfed8f
+-- hash: 353c6e8826db54054d40e456c6ba169c795c66f18c13b27370dafb4f2ad2132d
 
 name:           cardano-addresses
-version:        3.6.0
+version:        3.6.1
 synopsis:       Library utilities for mnemonic generation and address derivation.
 description:    Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>
 category:       Cardano

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -46,6 +46,7 @@ module Cardano.Address.Style.Shelley
       -- $addresses
     , InspectAddress (..)
     , AddressInfo (..)
+    , ReferenceInfo (..)
     , eitherInspectAddress
     , inspectAddress
     , inspectShelleyAddress
@@ -651,7 +652,7 @@ data AddressInfo = AddressInfo
 
 -- | Info from 'Address' about how delegation keys are located.
 --
--- @since 3.3.0
+-- @since 3.6.1
 data ReferenceInfo
     = ByValue
     | ByPointer ChainPointer

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,5 +1,5 @@
 name:                cardano-addresses
-version:             3.6.0
+version:             3.6.1
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK


### PR DESCRIPTION
Looks like exporting of `ReferenceInfo` was forgotten.

Bumped up the version too.