### PR TITLE
Introduce wallet id in cli and add hex-encoded option to hashing of keys 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ root_xsk1hqzfzrgskgnpwskxxrv5khs7ess82ecy8za9l5ef7e0afd2849p3zryje8chk39nxtva0sw
 </details>
 
 <details>
+  <summary>How to generate a wallet id based on extended root or account keys (<strong>phrase.prv</strong>)</summary>
+
+```console
+$ cat root.xsk
+root_xsk1hqzfzrgskgnpwskxxrv5khs7ess82ecy8za9l5ef7e0afd2849p3zryje8chk39nxtva0sww5me3pzkej4rvd5cae3q3v8eu7556n6pdrp4fdu8nsglynpmcppxxvfdyzdz5gfq3fefjepxhvqspmuyvmvqg8983
+$ cardano-address key walletid < root.xsk
+d5255b85024bf01b7719ac90cdfa79c8baf210f358e4f03c7880c300
+
+$ cardano-address key public --with-chain-code < root.xsk | cardano-address key walletid
+d5255b85024bf01b7719ac90cdfa79c8baf210f358e4f03c7880c300
+
+$ cardano-address key child 1852H/1815H/0H < root.xsk > acct.xsk
+$ cat acct.xsk
+acct_xsk15ztha8ws7qjze5vmdkwqh0ddzvtlgstkg79swazhc5lxns2849plr3msjx082mcmd9hc24ujczk2cjnjwrcz4tjaucw9jqf8h5yc7d84rac0zdckkuhazpam0kleg4sq52ph3e0wn98a64hr8g5cpmh9zqpwtrhy
+$ cardano-address key walletid < acct.xsk
+f6ff1f0d0ccfbef5445c88fd637e6be8e55d372389aa2d53bc6b16a7
+$ cardano-address key public --with-chain-code < acct.xsk | cardano-address key walletid
+f6ff1f0d0ccfbef5445c88fd637e6be8e55d372389aa2d53bc6b16a7
+```
+</details>
+
+
+<details>
   <summary>How to generate a payment verification key (<strong>addr.xvk</strong>)</summary>
 
 ```console

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ stake_xvk1658atzttunamzn80204khrg0qfdk5nvmrutlmmpg7xlsyaggwa7h9z4smmeqsvs67qhyqm
 </details>
 
 <details>
+  <summary>How to generate a hash for payment verification key (<strong>addr.xvk</strong>)</summary>
+
+```console
+$ cardano-address key child 1852H/1815H/0H/0/0 < root.xsk | cardano-address key public --with-chain-code > addr.xvk
+addr_xvk1grvg8qzmkmw2n0dm4pd0h3j4dv6yglyammyp733eyj629dc3z28v6wk22nfmru6xz0vl2s3y5xndyd57fu70hrt84c6zkvlwx6fdl7ct9j7yc
+$ cardano-address key hash < addr.xvk
+addr_vkh12j28hnmtwcp3n08vy58vyf0arnnrhtavu3lrfdztw0j0jng3d6v
+$ cardano-address key hash --hex < addr.xvk
+54947bcf6b760319bcec250ec225fd1ce63baface47e34b44b73e4f9
+```
+
+> :information_source: The hashing is available for both stake and payment verification keys. Additional flag '--hex' can be used.
+</details>
+
+
+<details>
   <summary>How to generate a payment address from a payment key (<strong>payment.addr</strong>)</summary>
 
 ```console

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -57,6 +57,7 @@ library
       Options.Applicative.Credential
       Options.Applicative.Derivation
       Options.Applicative.Discrimination
+      Options.Applicative.Format
       Options.Applicative.MnemonicSize
       Options.Applicative.Public
       Options.Applicative.Script

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -46,6 +46,7 @@ library
       Command.Key.Hash
       Command.Key.Inspect
       Command.Key.Public
+      Command.Key.WalletId
       Command.RecoveryPhrase
       Command.RecoveryPhrase.Generate
       Command.Script

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -125,6 +125,7 @@ test-suite unit
       Command.Key.HashSpec
       Command.Key.InspectSpec
       Command.Key.PublicSpec
+      Command.Key.WalletIdSpec
       Command.KeySpec
       Command.RecoveryPhrase.GenerateSpec
       Command.RecoveryPhraseSpec

--- a/command-line/lib/Command/Key.hs
+++ b/command-line/lib/Command/Key.hs
@@ -32,6 +32,7 @@ import qualified Command.Key.FromRecoveryPhrase as FromRecoveryPhrase
 import qualified Command.Key.Hash as Hash
 import qualified Command.Key.Inspect as Inspect
 import qualified Command.Key.Public as Public
+import qualified Command.Key.WalletId as WalletId
 
 data Cmd
     = FromRecoveryPhrase FromRecoveryPhrase.Cmd
@@ -39,6 +40,7 @@ data Cmd
     | Public Public.Cmd
     | Inspect Inspect.Cmd
     | Hash Hash.Cmd
+    | WalletId WalletId.Cmd
     deriving (Show)
 
 mod :: (Cmd -> parent) -> Mod CommandFields parent
@@ -76,6 +78,7 @@ mod liftCmd = command "key" $
         , Public.mod Public
         , Inspect.mod Inspect
         , Hash.mod Hash
+        , WalletId.mod WalletId
         ]
 
 run :: Cmd -> IO ()
@@ -85,3 +88,4 @@ run = \case
     Public sub -> Public.run sub
     Inspect sub -> Inspect.run sub
     Hash sub -> Hash.run sub
+    WalletId sub -> WalletId.run sub

--- a/command-line/lib/Command/Key/Hash.hs
+++ b/command-line/lib/Command/Key/Hash.hs
@@ -35,7 +35,7 @@ import System.IO.Extra
 import qualified Cardano.Codec.Bech32.Prefixes as CIP5
 import qualified Data.ByteString as BS
 
-data Cmd = Hash
+newtype Cmd = Hash
     { outputFormat :: FormatType
     } deriving (Show)
 

--- a/command-line/lib/Command/Key/WalletId.hs
+++ b/command-line/lib/Command/Key/WalletId.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Command.Key.WalletId
+    ( Cmd (..)
+    , mod
+    , run
+    ) where
+
+import Prelude hiding
+    ( mod )
+
+import Cardano.Address.Derivation
+    ( hashCredential, toXPub, xprvFromBytes, xpubToBytes )
+import Codec.Binary.Encoding
+    ( AbstractEncoding (..) )
+import Control.Monad
+    ( when )
+import Options.Applicative
+    ( CommandFields, Mod, command, footerDoc, helper, info, progDesc )
+import Options.Applicative.Help.Pretty
+    ( string )
+import System.IO
+    ( stdin, stdout )
+import System.IO.Extra
+    ( hGetBech32, hPutBytes )
+
+import qualified Cardano.Codec.Bech32.Prefixes as CIP5
+import qualified Data.ByteString as BS
+
+data Cmd = WalletId
+    deriving (Show)
+
+mod :: (Cmd -> parent) -> Mod CommandFields parent
+mod liftCmd = command "walletid" $
+    info (helper <*> fmap liftCmd parser) $ mempty
+        <> progDesc "Get the wallet id from a given key"
+        <> footerDoc (Just $ string $ mconcat
+            [ "The key is read from stdin."
+            ])
+  where
+    parser = pure WalletId
+
+run :: Cmd -> IO ()
+run WalletId = do
+    (hrp, bytes) <- hGetBech32 stdin allowedPrefixes
+    guardBytes hrp bytes
+    hPutBytes stdout (hashCredential $ payloadToHash hrp bytes) EBase16
+  where
+    allowedPrefixes =
+        [ CIP5.root_xsk
+        , CIP5.root_xvk
+        , CIP5.root_shared_xsk
+        , CIP5.root_shared_xvk
+        , CIP5.acct_xvk
+        , CIP5.acct_xsk
+        , CIP5.acct_shared_xvk
+        , CIP5.acct_shared_xsk
+        ]
+
+    payloadToHash hrp bs
+        | hrp `elem` [CIP5.root_xsk, CIP5.root_shared_xsk, CIP5.acct_xsk, CIP5.acct_shared_xsk] =
+              case xprvFromBytes bs of
+                  Just xprv ->  xpubToBytes . toXPub $ xprv
+                  Nothing -> "96-byte extended private key is invalid due to 'scalarDecodeLong' failure from cryptonite"
+        | otherwise =
+              bs
+
+    guardBytes hrp bytes
+        | hrp `elem` [CIP5.root_xsk, CIP5.root_shared_xsk, CIP5.acct_xsk, CIP5.acct_shared_xsk] = do
+            when (BS.length bytes /= 96) $
+                fail "data should be a 96-byte private key."
+
+        | otherwise = do
+            when (BS.length bytes /= 64) $
+                fail "data should be a 32-byte public key with a 32-byte chain-code appended."

--- a/command-line/lib/Command/Key/WalletId.hs
+++ b/command-line/lib/Command/Key/WalletId.hs
@@ -39,7 +39,11 @@ mod liftCmd = command "walletid" $
     info (helper <*> fmap liftCmd parser) $ mempty
         <> progDesc "Get the wallet id from a given key"
         <> footerDoc (Just $ string $ mconcat
-            [ "The key is read from stdin."
+            [ "The key is read from stdin and"
+            , "is assumed to be either extended root or extended account key."
+            , "Both extended private and extended public keys are accepted and"
+            , "the corresponding duals give rise to the same wallet id."
+            , "Wallet id is 28-byte hex-encoded Blake2b hash applied on an extended public key."
             ])
   where
     parser = pure WalletId

--- a/command-line/lib/Command/Key/WalletId.hs
+++ b/command-line/lib/Command/Key/WalletId.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 {-# OPTIONS_HADDOCK hide #-}

--- a/command-line/lib/Options/Applicative/Format.hs
+++ b/command-line/lib/Options/Applicative/Format.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Options.Applicative.Format
+    (
+    -- * Types
+      FormatType (..)
+
+    -- * Applicative Parser
+    , formatOpt
+    ) where
+
+import Prelude
+
+import Control.Applicative
+    ( (<|>) )
+import Options.Applicative
+    ( Parser, flag', long )
+
+
+data FormatType = Hex | Bech32
+    deriving (Eq, Show)
+
+--
+-- Applicative Parser
+--
+
+-- | Parse an 'FormatType' from the command-line, if there is proper flag then hex is set.
+formatOpt :: Parser FormatType
+formatOpt = hex <|> pure Bech32
+  where
+    hex = flag' Hex (long "hex")

--- a/command-line/test/Command/Key/WalletIdSpec.hs
+++ b/command-line/test/Command/Key/WalletIdSpec.hs
@@ -38,6 +38,10 @@ spec = describeCmd [ "key", "walletid" ] $ do
     specAcctKeyNotExtended "icarus" "1852H/1815H/0H"
     specAcctKeyNotExtended "shared" "1854H/1815H/0H"
 
+    specRootKeyNotExtended "shelley"
+    specRootKeyNotExtended "icarus"
+    specRootKeyNotExtended "shared"
+
 specKeyNeitherRootNorAcct :: String -> String -> String -> SpecWith ()
 specKeyNeitherRootNorAcct style path cc = it "fails if key is nether root nor account" $ do
     (out, err) <- cli [ "recovery-phrase", "generate" ] ""
@@ -53,6 +57,15 @@ specAcctKeyNotExtended style path = it "fails if account key is not extended" $ 
     (out, err) <- cli [ "recovery-phrase", "generate" ] ""
               >>= cli [ "key", "from-recovery-phrase", style ]
               >>= cli [ "key", "child", path ]
+              >>= cli [ "key", "public", "--without-chain-code" ]
+              >>= cli [ "key", "walletid"]
+    out `shouldBe` ""
+    err `shouldContain` "Invalid human-readable prefix."
+
+specRootKeyNotExtended :: String -> SpecWith ()
+specRootKeyNotExtended style = it "fails if root key is not extended" $ do
+    (out, err) <- cli [ "recovery-phrase", "generate" ] ""
+              >>= cli [ "key", "from-recovery-phrase", style ]
               >>= cli [ "key", "public", "--without-chain-code" ]
               >>= cli [ "key", "walletid"]
     out `shouldBe` ""

--- a/command-line/test/Command/Key/WalletIdSpec.hs
+++ b/command-line/test/Command/Key/WalletIdSpec.hs
@@ -34,12 +34,26 @@ spec = describeCmd [ "key", "walletid" ] $ do
     specKeyNeitherRootNorAcct "shared" "1854H/1815H/0H/2/0" "--without-chain-code"
     specKeyNeitherRootNorAcct "shared" "1854H/1815H/0H/2/0" "--with-chain-code"
 
+    specAcctKeyNotExtended "shelley" "1852H/1815H/0H"
+    specAcctKeyNotExtended "icarus" "1852H/1815H/0H"
+    specAcctKeyNotExtended "shared" "1854H/1815H/0H"
+
 specKeyNeitherRootNorAcct :: String -> String -> String -> SpecWith ()
 specKeyNeitherRootNorAcct style path cc = it "fails if key is nether root nor account" $ do
     (out, err) <- cli [ "recovery-phrase", "generate" ] ""
               >>= cli [ "key", "from-recovery-phrase", style ]
               >>= cli [ "key", "child", path ]
               >>= cli [ "key", "public", cc ]
+              >>= cli [ "key", "walletid"]
+    out `shouldBe` ""
+    err `shouldContain` "Invalid human-readable prefix."
+
+specAcctKeyNotExtended :: String -> String -> SpecWith ()
+specAcctKeyNotExtended style path = it "fails if account key is not extended" $ do
+    (out, err) <- cli [ "recovery-phrase", "generate" ] ""
+              >>= cli [ "key", "from-recovery-phrase", style ]
+              >>= cli [ "key", "child", path ]
+              >>= cli [ "key", "public", "--without-chain-code" ]
               >>= cli [ "key", "walletid"]
     out `shouldBe` ""
     err `shouldContain` "Invalid human-readable prefix."

--- a/command-line/test/Command/Key/WalletIdSpec.hs
+++ b/command-line/test/Command/Key/WalletIdSpec.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Command.Key.WalletIdSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Test.Hspec
+    ( Spec, SpecWith, it, shouldBe, shouldContain )
+import Test.Utils
+    ( cli, describeCmd )
+
+spec :: Spec
+spec = describeCmd [ "key", "walletid" ] $ do
+    specKeyNeitherRootNorAcct "shelley" "1852H/1815H/0H/0/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "shelley" "1852H/1815H/0H/0/0" "--with-chain-code"
+    specKeyNeitherRootNorAcct "shelley" "1852H/1815H/0H/1/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "shelley" "1852H/1815H/0H/1/0" "--with-chain-code"
+    specKeyNeitherRootNorAcct "shelley" "1852H/1815H/0H/2/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "shelley" "1852H/1815H/0H/2/0" "--with-chain-code"
+
+    specKeyNeitherRootNorAcct "icarus" "1852H/1815H/0H/0/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "icarus" "1852H/1815H/0H/0/0" "--with-chain-code"
+    specKeyNeitherRootNorAcct "icarus" "1852H/1815H/0H/1/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "icarus" "1852H/1815H/0H/1/0" "--with-chain-code"
+    specKeyNeitherRootNorAcct "icarus" "1852H/1815H/0H/2/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "icarus" "1852H/1815H/0H/2/0" "--with-chain-code"
+
+    specKeyNeitherRootNorAcct "shared" "1854H/1815H/0H/0/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "shared" "1854H/1815H/0H/0/0" "--with-chain-code"
+    specKeyNeitherRootNorAcct "shared" "1854H/1815H/0H/1/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "shared" "1854H/1815H/0H/1/0" "--with-chain-code"
+    specKeyNeitherRootNorAcct "shared" "1854H/1815H/0H/2/0" "--without-chain-code"
+    specKeyNeitherRootNorAcct "shared" "1854H/1815H/0H/2/0" "--with-chain-code"
+
+specKeyNeitherRootNorAcct :: String -> String -> String -> SpecWith ()
+specKeyNeitherRootNorAcct style path cc = it "fails if key is nether root nor account" $ do
+    (out, err) <- cli [ "recovery-phrase", "generate" ] ""
+              >>= cli [ "key", "from-recovery-phrase", style ]
+              >>= cli [ "key", "child", path ]
+              >>= cli [ "key", "public", cc ]
+              >>= cli [ "key", "walletid"]
+    out `shouldBe` ""
+    err `shouldContain` "Invalid human-readable prefix."

--- a/command-line/test/Command/Key/WalletIdSpec.hs
+++ b/command-line/test/Command/Key/WalletIdSpec.hs
@@ -47,6 +47,10 @@ spec = describeCmd [ "key", "walletid" ] $ do
     specRootKeyPubPrvHasEqualWalletId "icarus"
     specRootKeyPubPrvHasEqualWalletId "shared"
 
+    specAcctKeyPubPrvHasEqualWalletId "shelley" "1852H/1815H/0H"
+    specAcctKeyPubPrvHasEqualWalletId "icarus" "1852H/1815H/0H"
+    specAcctKeyPubPrvHasEqualWalletId "shared" "1854H/1815H/0H"
+
 specKeyNeitherRootNorAcct :: String -> String -> String -> SpecWith ()
 specKeyNeitherRootNorAcct style path cc = it "fails if key is nether root nor account" $ do
     (out, err) <- cli [ "recovery-phrase", "generate" ] ""
@@ -80,6 +84,18 @@ specRootKeyPubPrvHasEqualWalletId :: String -> SpecWith ()
 specRootKeyPubPrvHasEqualWalletId style = it "root private key and its public key give the same wallet id" $ do
     xprv <- cli [ "recovery-phrase", "generate" ] ""
         >>= cli [ "key", "from-recovery-phrase", style ]
+
+    walletidFromXPrv <- cli @String [ "key", "walletid"] xprv
+    walletidFromXPub <- cli [ "key", "public", "--with-chain-code" ] xprv
+                    >>= cli [ "key", "walletid"]
+
+    walletidFromXPrv `shouldBe` walletidFromXPub
+
+specAcctKeyPubPrvHasEqualWalletId :: String -> String -> SpecWith ()
+specAcctKeyPubPrvHasEqualWalletId style path = it "root private key and its public key give the same wallet id" $ do
+    xprv <- cli [ "recovery-phrase", "generate" ] ""
+        >>= cli [ "key", "from-recovery-phrase", style ]
+        >>= cli [ "key", "child", path ]
 
     walletidFromXPrv <- cli @String [ "key", "walletid"] xprv
     walletidFromXPub <- cli [ "key", "public", "--with-chain-code" ] xprv


### PR DESCRIPTION
ADP-1359

Two things were done.
1. It was added "key walletid" that works on EXTENDED root and account keys, both private and public, to get wallet id.
A number of tests were added.

2. Optional flag "--hex" was added to "key hash" command. If used, then instead of bech32-encoded output user gets hex-encoded one.
