### PR TITLE
Bump version from 3.7.0 to 3.8.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+## [3.8.0] - 2022-02-11
+
+### Added
+
+- Adds the `cardano-address key walletid` command, which derives a
+  [`cardano-wallet` wallet ID](https://input-output-hk.github.io/cardano-wallet/design/WalletId)
+  from a wallet key.
+
 ## [3.7.0] - 2021-12-15
 
 ### Added

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.5.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e004ba80ba31b630648dc692f4d8df656f2b09c7d72a12c92512076bb5ced55f
+-- hash: 3512e1fadf0c32f4be17a1fadc962e8c47818fdde6fd07f0f1a504a6212a98e5
 
 name:           cardano-addresses-cli
-version:        3.7.0
+version:        3.8.0
 synopsis:       Utils for constructing a command-line on top of cardano-addresses.
 description:    Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>
 category:       Cardano
@@ -15,7 +15,7 @@ homepage:       https://github.com/input-output-hk/cardano-addresses#readme
 bug-reports:    https://github.com/input-output-hk/cardano-addresses/issues
 author:         IOHK
 maintainer:     operations@iohk.io
-copyright:      2021 IOHK
+copyright:      2021-2022 IOHK
 license:        Apache-2.0
 build-type:     Simple
 extra-source-files:

--- a/command-line/lib/Command/Key/WalletId.hs
+++ b/command-line/lib/Command/Key/WalletId.hs
@@ -37,13 +37,17 @@ data Cmd = WalletId
 mod :: (Cmd -> parent) -> Mod CommandFields parent
 mod liftCmd = command "walletid" $
     info (helper <*> fmap liftCmd parser) $ mempty
-        <> progDesc "Get the wallet id from a given key"
+        <> progDesc "Shows the cardano-wallet wallet ID for a given key"
         <> footerDoc (Just $ string $ mconcat
-            [ "The key is read from stdin and"
-            , "is assumed to be either extended root or extended account key."
-            , "Both extended private and extended public keys are accepted and"
-            , "the corresponding duals give rise to the same wallet id."
-            , "Wallet id is hex-encoded Blake2b-160 hash applied on an extended public key."
+            [ "A wallet ID is a 40-digit hexadecimal string derived "
+            , "from the wallet’s mnemonic. It is used by the cardano-wallet "
+            , "server to refer to specific wallets.\n\n"
+            , "This key can be either an extended root key "
+            , "(full multi-account wallets), or an extended account key "
+            , "(single-account wallets).\n\n"
+            , "Private or public extended keys are accepted -- they will have "
+            , "the same wallet ID.\n\n"
+            , "The bech32-encoded key is read from standard input.\n"
             ])
   where
     parser = pure WalletId

--- a/command-line/package.yaml
+++ b/command-line/package.yaml
@@ -1,10 +1,10 @@
 name:                cardano-addresses-cli
-version:             3.7.0
+version:             3.8.0
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2021 IOHK
+copyright:           2021-2022 IOHK
 synopsis:            Utils for constructing a command-line on top of cardano-addresses.
 category:            Cardano
 

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.5.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e23c4cda55a011821f3a6a26083bc6acd3d0d34829f0a839f3bc5d9f8f265db6
+-- hash: a630e24949e30ca4d40aed7cf07f9f3462dbc8d9746f6c7f451cb8614164737d
 
 name:           cardano-addresses
-version:        3.7.0
+version:        3.8.0
 synopsis:       Library utilities for mnemonic generation and address derivation.
 description:    Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>
 category:       Cardano
@@ -15,7 +15,7 @@ homepage:       https://github.com/input-output-hk/cardano-addresses#readme
 bug-reports:    https://github.com/input-output-hk/cardano-addresses/issues
 author:         IOHK
 maintainer:     operations@iohk.io
-copyright:      2021 IOHK
+copyright:      2021-2022 IOHK
 license:        Apache-2.0
 build-type:     Simple
 

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,10 +1,10 @@
 name:                cardano-addresses
-version:             3.7.0
+version:             3.8.0
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2021 IOHK
+copyright:           2021-2022 IOHK
 synopsis:            Library utilities for mnemonic generation and address derivation.
 category:            Cardano
 

--- a/jsapi/cardano-addresses-jsapi.cabal
+++ b/jsapi/cardano-addresses-jsapi.cabal
@@ -1,13 +1,6 @@
 cabal-version: 3.0
-
--- This file has been generated from package.yaml by hpack version 0.34.4.
---
--- see: https://github.com/sol/hpack
---
--- hash: 80c299032534b3b108a856c47ce3217e9ff997a28b796ef725eda9ea6f137cc7
-
 name:           cardano-addresses-jsapi
-version:        3.7.0
+version:        3.8.0
 synopsis:       Javascript FFI for cardano-addresses.
 description:    This package provides functions callable from Javascript on top of
                 which a TypeScript API can be built. It uses the cardano-addresses-ghcjs

--- a/jsapi/package-lock.json
+++ b/jsapi/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-addresses",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/jsapi/package.json
+++ b/jsapi/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.0",
+  "version": "3.8.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/jsbits/cardano-addresses-jsbits.cabal
+++ b/jsbits/cardano-addresses-jsbits.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.5.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9a1320f8b01cbdd364a4cd8ecaf7271a9fccc8e6313e7eff4b30f7e66f86b376
+-- hash: ac01f98f4de50a522b7da05f3913a4c6c5c486125f2d3c7bc05754027dec0c31
 
 name:           cardano-addresses-jsbits
-version:        3.7.0
+version:        3.8.0
 synopsis:       Javascript code for ghcjs build of cardano-addresses.
 description:    This package supports ghcjs compilation of cardano-addresses with
                 Javascript wrappers and Emscripten builds of the cryptonite C
@@ -17,7 +17,7 @@ homepage:       https://github.com/input-output-hk/cardano-addresses#readme
 bug-reports:    https://github.com/input-output-hk/cardano-addresses/issues
 author:         IOHK
 maintainer:     operations@iohk.io
-copyright:      2021 IOHK
+copyright:      2021-2022 IOHK
 license:        Apache-2.0
 build-type:     Simple
 

--- a/jsbits/package.yaml
+++ b/jsbits/package.yaml
@@ -1,10 +1,10 @@
 name:                cardano-addresses-jsbits
-version:             3.7.0
+version:             3.8.0
 github:              input-output-hk/cardano-addresses
 license:             Apache-2.0
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2021 IOHK
+copyright:           2021-2022 IOHK
 synopsis:            Javascript code for ghcjs build of cardano-addresses.
 category:            Cardano
 


### PR DESCRIPTION
- Bump the cardano-addresses version for a new release.
- Add release notes
- Improve the text of `cardano-address key walletid --help`
