### PR TITLE
Attempt to fix windows build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,9 +34,9 @@ jobs:
     - name: 📸 Build Snapshot
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
-        curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
-        stack --no-terminal exec -- pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
+        curl -O https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20211228-1-any.pkg.tar.zst
+        curl -O https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20211228-1-any.pkg.tar.zst.sig
+        stack --no-terminal exec -- pacman -U --noconfirm msys2-keyring-1~20211228-1-any.pkg.tar.zst
         stack --no-terminal exec -- pacman -Syu --no-confirm
         stack --no-terminal exec -- pacman -S --noconfirm mingw-w64-x86_64-pcre
         stack --no-terminal exec -- pacman -S --noconfirm mingw-w64-x86_64-pkg-config


### PR DESCRIPTION
Seeing this in Windows builds (https://github.com/input-output-hk/cardano-addresses/runs/5154477094?check_suite_focus=true)
```
checking package integrity...
error: mingw-w64-x86_64-mpfr: signature from "David Macek <david.macek.0@gmail.com>" is unknown trust
:: File /var/cache/pacman/pkg/mingw-w64-x86_64-mpfr-4.1.0-3-any.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
```
Trying to apply some workarounds:
 - https://github.com/msys2/MSYS2-packages/issues/2343
 - https://stackoverflow.com/questions/68669920/invalid-pgp-signature-when-updating-packages-in-msys2-despite-fixes

_(don't really know what I'm doing)_