### PR TITLE
Aeson 1 & 2 compatibility

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,53 @@
+name: Binaries
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ["8.10.7"]
+        os: [ubuntu-latest]
+        aeson: ["1.5.6.0", "2.0.3.0"]
+        exclude:
+          - ghc: "9.2.2"
+            aeson: "1.5.6.0"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: haskell/actions/setup@v1
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: 3.6.2.0
+
+      - name: Configure project
+        run: |
+          # We can't update the index state yet because nix flake is locked to an earlier one.
+          sed -i 's|^index-state:.*$|index-state: 2022-04-04T00:00:00Z|g' cabal.project
+          cabal configure --enable-tests --write-ghc-environment-files=ghc8.4.4+ --constraint="aeson == ${{ matrix.aeson }}"
+
+      - uses: actions/cache@v2
+        name: Cache cabal store
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: cache-${{ runner.os }}-${{ matrix.ghc }}
+          restore-keys: cache-${{ runner.os }}-${{ matrix.ghc }}
+
+      - name: Build
+        run: cabal build all --enable-tests
+
+      - name: Test
+        run: cabal test cardano-addresses:unit cardano-addresses-cli:unit --enable-tests

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         ghc: ["8.10.7"]
         os: [ubuntu-latest]
+        # TODO This is used to test the project compiles with aeson 1 & 2.  This can be moved when the
+        # library is modified to work strictly with aeson-2 only, which can only be done once all
+        # downstream projects have upgraded to aeson 2.
         aeson: ["1.5.6.0", "2.0.3.0"]
         exclude:
           - ghc: "9.2.2"

--- a/cabal.project
+++ b/cabal.project
@@ -29,18 +29,29 @@ source-repository-package
     --sha256: 0cbsj3dyycykh0lcnsglrzzh898n2iydyw8f2nwyfvfnyx6ac2im
     subdir: foundation
 
+-- TODO This was patched to work with aeson 1 & 2 with the help of hw-aeson.
+-- Once downstream projects are all upgraded to work with aeson-2, they can
+-- be changed to work strictly with aeson 2 only. 
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/hjsonpointer
     tag: bb99294424e0c5b3c2942c743b545e4b01c12ce8
     --sha256: 11z5s4xmm6cxy6sdcf9ly4lr0qh3c811hpm0bmlp4c3yq8v3m9rk
 
+-- TODO This was patched to work with aeson 1 & 2 with the help of hw-aeson.
+-- Once downstream projects are all upgraded to work with aeson-2, they can
+-- be changed to work strictly with aeson 2 only.
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/hjsonschema
     tag: 1546af7fc267d5eea805ef223dd2b59ac120b784
     --sha256: 0sdikhsq6nnhmmvcpwzzrwfn9cn7rg75629qnrx01i5vm5ci4314
 
+-- TODO This is a compatibility shim to make it easier for our library dependencies to
+-- be compatible with both aeson 1 & 2.  Once downstream projects are all upgraded to
+-- work with aeson-2, library dependencies will need to be updated to no longer use
+-- this compatibility shim and have bounds to indicate they work with aeson-2 only.
+-- After this, the dependency to hw-aeson can be dropped.
 source-repository-package
     type: git
     location: https://github.com/haskell-works/hw-aeson

--- a/cabal.project
+++ b/cabal.project
@@ -31,10 +31,21 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/ghcjs/jsaddle
-    tag: 9cb3534b6b2dc948c6fa88fce281e59e904b43e4
-    --sha256: 1drgrgjnxamq8vh6mrqg62xcj7vb9makpy89bls485d6ckigv3ha
-    subdir: jsaddle
+    location: https://github.com/input-output-hk/hjsonpointer
+    tag: bb99294424e0c5b3c2942c743b545e4b01c12ce8
+    --sha256: 11z5s4xmm6cxy6sdcf9ly4lr0qh3c811hpm0bmlp4c3yq8v3m9rk
+
+source-repository-package
+    type: git
+    location: https://github.com/input-output-hk/hjsonschema
+    tag: 1546af7fc267d5eea805ef223dd2b59ac120b784
+    --sha256: 0sdikhsq6nnhmmvcpwzzrwfn9cn7rg75629qnrx01i5vm5ci4314
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell-works/hw-aeson
+    tag: d99d2f3e39a287607418ae605b132a3deb2b753f
+    --sha256: 1vxqcwjg9q37wbwi27y9ba5163lzfz51f1swbi0rp681yg63zvn4
 
 -- Relax overly strict bounds in hjsonschema and hjsonpointer
 allow-newer:
@@ -48,3 +59,6 @@ allow-newer:
   , stm:base
 
 test-show-details: direct
+
+allow-newer:
+  *:aeson

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.6.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 --

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.6.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9f30f9f522077c62c5cb3d84870f93f7e17356724b5df8edb6f1a8c14c74bf72
+-- hash: 71777847181ac1ed3a185c266d10fd57f8a0262f63c0976da3b9d6526f923038
 
 name:           cardano-addresses
 version:        3.10.0
@@ -72,6 +72,7 @@ library
     , extra
     , fmt
     , hashable
+    , hw-aeson
     , memory
     , text
     , unordered-containers

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -54,6 +54,7 @@ library:
   - exceptions
   - extra
   - fmt
+  - hw-aeson
   - hashable
   - memory
   - text

--- a/jsbits/cardano-addresses-jsbits.cabal
+++ b/jsbits/cardano-addresses-jsbits.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.6.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,10 +12,20 @@ extra-deps:
 - bech32-th-1.1.1
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec
+- git: https://github.com/ghcjs/jsaddle
+  commit: c4b7c6cebf09447a25105d7c839914d7378bf5a7
+  subdirs:
+  - jsaddle
 
-# dependencies for testing.
-- hjsonpointer-1.5.0
-- hjsonschema-1.10.0
+- git: https://github.com/input-output-hk/hjsonpointer
+  commit: bb99294424e0c5b3c2942c743b545e4b01c12ce8
+
+- git: https://github.com/input-output-hk/hjsonschema
+  commit: 1546af7fc267d5eea805ef223dd2b59ac120b784
+
+- git: https://github.com/haskell-works/hw-aeson
+  commit: d99d2f3e39a287607418ae605b132a3deb2b753f
+
 - string-interpolate-0.3.0.2
 - hspec-golden-0.1.0.3
 - pretty-simple-4.0.0.0


### PR DESCRIPTION
Make it possible to compile with both versions of `aeson` so downstream projects can be on whatever they need.

This change is meant to be temporary.  A full upgrade to `aeson-2` would occur when all downstream projects have completed their migration.