### PR TITLE
Extend payment share key derivation

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,9 +34,12 @@ jobs:
     - name: 📸 Build Snapshot
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        curl -O https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20211228-1-any.pkg.tar.zst
-        curl -O https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20211228-1-any.pkg.tar.zst.sig
-        stack --no-terminal exec -- pacman -U --noconfirm msys2-keyring-1~20211228-1-any.pkg.tar.zst
+        # Update keyring to allow packages signed by recent contributors:
+        #
+        #   error: mingw-w64-x86_64-mpc: signature from "David Macek <david.macek.0@gmail.com>" is unknown trust
+        curl -O https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20220623-1-any.pkg.tar.zst
+        curl -O https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20220623-1-any.pkg.tar.zst.siz
+        stack --no-terminal exec -- pacman -U --noconfirm msys2-keyring-1~20220623-1-any.pkg.tar.zst
         stack --no-terminal exec -- pacman -Syu --no-confirm
         stack --no-terminal exec -- pacman -S --noconfirm mingw-w64-x86_64-pcre
         stack --no-terminal exec -- pacman -S --noconfirm mingw-w64-x86_64-pkg-config

--- a/core/lib/Cardano/Address/Style/Shared.hs
+++ b/core/lib/Cardano/Address/Style/Shared.hs
@@ -200,10 +200,10 @@ deriveAccountPrivateKey = Internal.deriveAccountPrivateKey
 -- @since 3.4.0
 deriveAddressPrivateKey
     :: Shared 'AccountK XPrv
+    -> Role
     -> Index 'Soft 'PaymentK
     -> Shared 'ScriptK XPrv
-deriveAddressPrivateKey accPrv = coerce .
-    Internal.deriveAddressPrivateKey accPrv UTxOExternal
+deriveAddressPrivateKey = coerce . Internal.deriveAddressPrivateKey
 
 -- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock.
 --
@@ -224,10 +224,10 @@ deriveDelegationPrivateKey accPrv = coerce .
 -- @since 3.4.0
 deriveAddressPublicKey
     :: Shared 'AccountK XPub
+    -> Role
     -> Index 'Soft 'PaymentK
     -> Shared 'ScriptK XPub
-deriveAddressPublicKey accPub = coerce .
-    Internal.deriveAddressPublicKey accPub UTxOExternal
+deriveAddressPublicKey = coerce . Internal.deriveAddressPublicKey
 
 -- Re-export from 'Cardano.Address.Derivation' to have it documented specialized in Haddock
 --

--- a/core/test/Cardano/Address/ScriptSpec.hs
+++ b/core/test/Cardano/Address/ScriptSpec.hs
@@ -46,6 +46,8 @@ import Cardano.Address.Script.Parser
     ( requireCosignerOfParser, scriptFromString, scriptToText )
 import Cardano.Address.Style.Shared
     ( Shared (..), hashKey )
+import Cardano.Address.Style.Shelley
+    ( Role (..) )
 import Cardano.Mnemonic
     ( mkSomeMnemonic )
 import Codec.Binary.Encoding
@@ -96,20 +98,22 @@ spec = do
     let rootK = Shared.genMasterKeyFromMnemonic mw sndFactor :: Shared 'RootK XPrv
     let accXPrv = Shared.deriveAccountPrivateKey rootK minBound
 
+    let role' = UTxOExternal
+
     let index1 = minBound
-    let multisigXPub1 = toXPub <$> Shared.deriveAddressPrivateKey accXPrv index1
+    let multisigXPub1 = toXPub <$> Shared.deriveAddressPrivateKey accXPrv role' index1
     let verKeyHash1 = RequireSignatureOf $ hashKey Payment multisigXPub1
 
     let Just index2 = indexFromWord32 @(Index 'Soft _) 0x00000001
-    let multisigXPub2 = toXPub <$> Shared.deriveAddressPrivateKey accXPrv index2
+    let multisigXPub2 = toXPub <$> Shared.deriveAddressPrivateKey accXPrv role' index2
     let verKeyHash2 = RequireSignatureOf $ hashKey Payment multisigXPub2
 
     let Just index3 = indexFromWord32 @(Index 'Soft _) 0x00000002
-    let multisigXPub3 = toXPub <$> Shared.deriveAddressPrivateKey accXPrv index3
+    let multisigXPub3 = toXPub <$> Shared.deriveAddressPrivateKey accXPrv role' index3
     let verKeyHash3 = RequireSignatureOf $ hashKey Payment multisigXPub3
 
     let Just index4 = indexFromWord32 @(Index 'Soft _) 0x00000003
-    let multisigXPub4 = toXPub <$> Shared.deriveAddressPrivateKey accXPrv index4
+    let multisigXPub4 = toXPub <$> Shared.deriveAddressPrivateKey accXPrv role' index4
     let verKeyHash4 = RequireSignatureOf $ hashKey Payment multisigXPub4
 
     let multisigXPub5 = toXPub <$> Shared.deriveDelegationPrivateKey accXPrv index4


### PR DESCRIPTION
ADP-1623

Allowing to derive payment address, both private and public, for both UTxOInternal and UTxOExternal. It is needed in multisig work in cardano-wallet