### PR TITLE
Enable using key hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ addr_test1vp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f7guscp6v
 </details>
 
 <details>
+  <summary>How to generate a payment address from a payment key hash (<strong>payment.addr</strong>)</summary>
+
+```console
+$ cardano-address key hash < addr.xvk > addr.vkh
+addr_vkh12j28hnmtwcp3n08vy58vyf0arnnrhtavu3lrfdztw0j0jng3d6v
+$ cardano-address address payment --network-tag testnet < addr.vkh > payment.addr
+addr_test1vp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f7guscp6v
+```
+</details>
+
+
+<details>
   <summary>How to generate a delegated payment address from a stake key (<strong>payment-delegated.addr</strong>)</summary>
 
 ```console

--- a/README.md
+++ b/README.md
@@ -185,10 +185,21 @@ addr_test1vp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f7guscp6v
 
 
 <details>
-  <summary>How to generate a delegated payment address from a stake key (<strong>payment-delegated.addr</strong>)</summary>
+  <summary>How to generate a delegated payment address, ie. base address, from a stake key (<strong>base.addr</strong>)</summary>
 
 ```console
-$ cardano-address address delegation $(cat stake.xvk) < payment.addr > payment-delegated.addr
+$ cardano-address address delegation $(cat stake.xvk) < payment.addr > base.addr
+addr_test1qp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f70k6tew7wrnx0s4465nx05ajz890g44z0kx6a3gsnms4c4qq8ve0n
+```
+</details>
+
+<details>
+  <summary>How to generate a delegated payment address, ie. base address, from a stake key hash (<strong>base.addr</strong>)</summary>
+
+```console
+$ cardano-address key hash < stake.xvk > stake.vkh
+stake_vkh17mf09mecwve7zkh2jve7nkggu4azk5f7cmtk9zz0wzhz5efq2w6
+$ cardano-address address delegation $(cat stake.vkh) < payment.addr > base.addr
 addr_test1qp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f70k6tew7wrnx0s4465nx05ajz890g44z0kx6a3gsnms4c4qq8ve0n
 ```
 </details>
@@ -198,7 +209,18 @@ addr_test1qp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f70k6tew7wrnx0s4465nx05ajz
 
 ```console
 $ cardano-address address stake --network-tag testnet < stake.xvk > stake.addr
-stake_test1urmd9uh08pen8c26a2fn86weprjh52638mrdwc5gfac2u2s25zpat%
+stake_test1urmd9uh08pen8c26a2fn86weprjh52638mrdwc5gfac2u2s25zpat
+```
+</details>
+
+<details>
+  <summary>How to generate a stake address from a stake key hash (<strong>stake.addr</strong>)</summary>
+
+```console
+$ cardano-address key hash < stake.xvk > stake.vkh
+stake_vkh17mf09mecwve7zkh2jve7nkggu4azk5f7cmtk9zz0wzhz5efq2w6
+$ cardano-address address stake --network-tag testnet < stake.vkh > stake.addr
+stake_test1urmd9uh08pen8c26a2fn86weprjh52638mrdwc5gfac2u2s25zpat
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ addr_test1vp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f7guscp6v
 
 
 <details>
-  <summary>How to generate a delegated payment address, ie. base address, from a stake key (<strong>base.addr</strong>)</summary>
+  <summary>How to generate a delegated payment address, i.e. base address, from a stake key (<strong>base.addr</strong>)</summary>
 
 ```console
 $ cardano-address address delegation $(cat stake.xvk) < payment.addr > base.addr
@@ -194,7 +194,7 @@ addr_test1qp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f70k6tew7wrnx0s4465nx05ajz
 </details>
 
 <details>
-  <summary>How to generate a delegated payment address, ie. base address, from a stake key hash (<strong>base.addr</strong>)</summary>
+  <summary>How to generate a delegated payment address, i.e. base address, from a stake key hash (<strong>base.addr</strong>)</summary>
 
 ```console
 $ cardano-address key hash < stake.xvk > stake.vkh
@@ -304,7 +304,7 @@ $ cardano-address script hash "all [$(cat addr_shared.1.vk), $(cat addr_shared.2
 script1gr69m385thgvkrtspk73zmkwk537wxyxuevs2u9cukglvtlkz4k
 ```
 
-This script requires the signature from both signing keys corresponding to `shared_addr.1.vk` and `shared_addr.2.vk` (ie., shared_addr.1.sk and shared_addr.2.sk) in order to be valid. Similarly, we could require only one of the two signatures:
+This script requires the signature from both signing keys corresponding to `shared_addr.1.vk` and `shared_addr.2.vk` (i.e., shared_addr.1.sk and shared_addr.2.sk) in order to be valid. Similarly, we could require only one of the two signatures:
 
 We can also use extended verification, eiher payment or delegation, keys. They can be obtained as the non-extended ones by using `--with-chain-code` option rather than `--without-chain-option` as above. They will give rise to the same script hash as for verification keys chain code is stripped upon calculation.
 

--- a/command-line/lib/Command/Address/Delegation.hs
+++ b/command-line/lib/Command/Address/Delegation.hs
@@ -76,6 +76,8 @@ run Cmd{credential} = do
             fail msg
         Left (ErrInvalidAddressType  msg) ->
             fail msg
+        Left (ErrInvalidKeyHashType msg) ->
+            fail msg
         Right addr ->
             B8.hPutStr stdout $ T.encodeUtf8 $ bech32 addr
   where

--- a/command-line/lib/Command/Address/Payment.hs
+++ b/command-line/lib/Command/Address/Payment.hs
@@ -19,7 +19,7 @@ import Cardano.Address
 import Cardano.Address.Derivation
     ( xpubFromBytes )
 import Cardano.Address.Script
-    ( scriptHashFromBytes )
+    ( KeyRole (..), keyHashFromBytes, scriptHashFromBytes )
 import Cardano.Address.Style.Shelley
     ( Credential (..), shelleyTestnet )
 import Codec.Binary.Encoding
@@ -83,6 +83,7 @@ run Cmd{networkTag} = do
     -- this stage, so leaving this as an item for later.
     allowedPrefixes =
         [ CIP5.addr_xvk
+        , CIP5.addr_vkh
         , CIP5.script
         ]
 
@@ -93,6 +94,14 @@ run Cmd{networkTag} = do
                     fail "Couldn't convert bytes into script hash."
                 Just h  -> do
                     let credential = PaymentFromScript h
+                    pure $ Shelley.paymentAddress discriminant credential
+
+        | hrp == CIP5.addr_vkh = do
+            case keyHashFromBytes (Payment, bytes) of
+                Nothing  ->
+                    fail "Couldn't convert bytes into payment key hash."
+                Just keyhash -> do
+                    let credential = PaymentFromKeyHash keyhash
                     pure $ Shelley.paymentAddress discriminant credential
 
         | otherwise = do

--- a/command-line/lib/Command/Address/Pointer.hs
+++ b/command-line/lib/Command/Address/Pointer.hs
@@ -87,7 +87,9 @@ run Cmd{slotNum,transactionIndex,outputIndex} = do
     case Shelley.extendAddress (unsafeMkAddress bytes) (DelegationFromPointer ptr) of
         Left (ErrInvalidAddressStyle msg) ->
             fail msg
-        Left (ErrInvalidAddressType  msg) ->
+        Left (ErrInvalidAddressType msg) ->
+            fail msg
+        Left (ErrInvalidKeyHashType msg) ->
             fail msg
         Right addr ->
             B8.hPutStr stdout $ T.encodeUtf8 $ bech32 addr

--- a/command-line/lib/Command/Address/Reward.hs
+++ b/command-line/lib/Command/Address/Reward.hs
@@ -17,7 +17,7 @@ import Cardano.Address
 import Cardano.Address.Derivation
     ( xpubFromBytes )
 import Cardano.Address.Script
-    ( scriptHashFromBytes )
+    ( KeyRole (..), keyHashFromBytes, scriptHashFromBytes )
 import Cardano.Address.Style.Shelley
     ( Credential (..), shelleyTestnet, unsafeFromRight )
 import Codec.Binary.Encoding
@@ -84,6 +84,7 @@ run Cmd{networkTag} = do
     -- this stage, so leaving this as an item for later.
     allowedPrefixes =
         [ CIP5.stake_xvk
+        , CIP5.stake_vkh
         , CIP5.script
         ]
 
@@ -94,6 +95,14 @@ run Cmd{networkTag} = do
                     fail "Couldn't convert bytes into script hash."
                 Just h  -> do
                     let credential = DelegationFromScript h
+                    pure $ unsafeFromRight $ Shelley.stakeAddress discriminant credential
+
+        | hrp == CIP5.stake_vkh = do
+            case keyHashFromBytes (Delegation, bytes) of
+                Nothing  ->
+                    fail "Couldn't convert bytes into delegation key hash."
+                Just keyhash -> do
+                    let credential = DelegationFromKeyHash keyhash
                     pure $ unsafeFromRight $ Shelley.stakeAddress discriminant credential
 
         | otherwise = do

--- a/command-line/lib/Options/Applicative/Derivation.hs
+++ b/command-line/lib/Options/Applicative/Derivation.hs
@@ -26,10 +26,11 @@ module Options.Applicative.Derivation
     , derivationIndexToString
     , derivationIndexFromString
 
-    -- * XPub / XPrv
+    -- * XPub / XPrv / KeyHash
     , xpubReader
     , xpubOpt
     , xpubArg
+    , keyhashReader
 
     -- * Internal
     , bech32Reader
@@ -39,6 +40,8 @@ import Prelude
 
 import Cardano.Address.Derivation
     ( DerivationType (..), Index, XPub, wholeDomainIndex, xpubFromBytes )
+import Cardano.Address.Script
+    ( KeyHash (..), KeyRole (..), keyHashFromBytes )
 import Codec.Binary.Bech32
     ( HumanReadablePart, humanReadablePartToText )
 import Codec.Binary.Encoding
@@ -209,6 +212,14 @@ xpubArg allowedPrefixes helpDoc =
     argument (eitherReader (xpubReader allowedPrefixes)) $ mempty
         <> metavar "XPUB"
         <> help helpDoc
+
+keyhashReader :: (KeyRole, [HumanReadablePart]) -> String -> Either String KeyHash
+keyhashReader (keyrole, allowedPrefixes) str = do
+    (_hrp, bytes) <- bech32Reader allowedPrefixes str
+    case keyHashFromBytes (keyrole, bytes) of
+        Just keyhash -> pure keyhash
+        Nothing   -> Left
+            "Failed to convert bytes into a valid public key hash."
 
 --
 -- Internal

--- a/command-line/test/Command/Address/DelegationSpec.hs
+++ b/command-line/test/Command/Address/DelegationSpec.hs
@@ -23,6 +23,16 @@ spec = describeCmd [ "address", "delegation" ] $ do
         "addr_test1qptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwv\
         \xwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwk2gqr"
 
+    specFromKeyHash defaultPhrase "1852H/1815H/0H/2/0"
+        defaultAddrMainnet
+        "addr1q9therz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwvxwdrt\
+        \70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qdqhgvu"
+
+    specFromKeyHash defaultPhrase "1852H/1815H/0H/2/0"
+        defaultAddrTestnet
+        "addr_test1qptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwv\
+        \xwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwk2gqr"
+
     specFromScript
         defaultAddrMainnet
         "all [stake_shared_vkh1nqc00hvlc6cq0sfhretk0rmzw8dywmusp8retuqnnxzajtzhjg5]"
@@ -54,6 +64,15 @@ specFromKey phrase path addr want = it ("delegation from key " <> want) $ do
        >>= cli [ "key", "child", path ]
        >>= cli [ "key", "public", "--with-chain-code" ]
     out <- cli [ "address", "delegation", stakeKey ] addr
+    out `shouldBe` want
+
+specFromKeyHash :: [String] -> String -> String -> String -> SpecWith ()
+specFromKeyHash phrase path addr want = it ("delegation from key " <> want) $ do
+    stakeKeyHash <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
+       >>= cli [ "key", "child", path ]
+       >>= cli [ "key", "public", "--with-chain-code" ]
+       >>= cli [ "key", "hash" ]
+    out <- cli [ "address", "delegation", stakeKeyHash ] addr
     out `shouldBe` want
 
 specFromScript :: String -> String -> String -> SpecWith ()

--- a/command-line/test/Command/Address/PaymentSpec.hs
+++ b/command-line/test/Command/Address/PaymentSpec.hs
@@ -25,6 +25,18 @@ spec = describeCmd [ "address", "payment" ] $ do
     specShelley defaultPhrase "1852H/1815H/0H/0/0" "mainnet"
         "addr1v9u5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0kvk0f"
 
+    specShelleyFromKeyHash defaultPhrase "1852H/1815H/0H/0/0" "0"
+        "addr_test1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg57c2qv"
+
+    specShelleyFromKeyHash defaultPhrase "1852H/1815H/0H/0/0" "3"
+        "addr1vdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0m9a08"
+
+    specShelleyFromKeyHash defaultPhrase "1852H/1815H/0H/0/0" "testnet"
+        "addr_test1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg57c2qv"
+
+    specShelleyFromKeyHash defaultPhrase "1852H/1815H/0H/0/0" "mainnet"
+        "addr1v9u5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0kvk0f"
+
     specMalformedNetwork "💩"
 
     specInvalidNetwork "42"
@@ -35,6 +47,15 @@ specShelley phrase path networkTag want = it ("golden shelley (payment) " <> pat
     out <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
        >>= cli [ "key", "child", path ]
        >>= cli [ "key", "public", "--with-chain-code" ]
+       >>= cli [ "address", "payment", "--network-tag", networkTag ]
+    out `shouldBe` want
+
+specShelleyFromKeyHash :: [String] -> String -> String -> String -> SpecWith ()
+specShelleyFromKeyHash phrase path networkTag want = it ("golden shelley (payment) " <> path) $ do
+    out <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
+       >>= cli [ "key", "child", path ]
+       >>= cli [ "key", "public", "--with-chain-code" ]
+       >>= cli [ "key", "hash" ]
        >>= cli [ "address", "payment", "--network-tag", networkTag ]
     out `shouldBe` want
 

--- a/command-line/test/Command/Address/RewardSpec.hs
+++ b/command-line/test/Command/Address/RewardSpec.hs
@@ -19,6 +19,12 @@ spec = describeCmd [ "address", "stake" ] $ do
     specShelley defaultPhrase "1852H/1815H/0H/2/0" 3
         "stake1u0a3dk68y6echdmfmnvm8mej8u5truwv8ufmv830w5a45tchw5z0e"
 
+    specShelleyFromKeyHash defaultPhrase "1852H/1815H/0H/2/0" 0
+        "stake_test1ura3dk68y6echdmfmnvm8mej8u5truwv8ufmv830w5a45tcsfhtt2"
+
+    specShelleyFromKeyHash defaultPhrase "1852H/1815H/0H/2/0" 3
+        "stake1u0a3dk68y6echdmfmnvm8mej8u5truwv8ufmv830w5a45tchw5z0e"
+
     specMalformedNetwork "💩"
 
     specInvalidNetwork "42"
@@ -28,6 +34,15 @@ specShelley phrase path networkTag want = it ("golden shelley (payment) " <> pat
     out <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
        >>= cli [ "key", "child", path ]
        >>= cli [ "key", "public", "--with-chain-code" ]
+       >>= cli [ "address", "stake", "--network-tag", show networkTag ]
+    out `shouldBe` want
+
+specShelleyFromKeyHash :: [String] -> String -> Int -> String -> SpecWith ()
+specShelleyFromKeyHash phrase path networkTag want = it ("golden shelley (payment) " <> path) $ do
+    out <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
+       >>= cli [ "key", "child", path ]
+       >>= cli [ "key", "public", "--with-chain-code" ]
+       >>= cli [ "key", "hash" ]
        >>= cli [ "address", "stake", "--network-tag", show networkTag ]
     out `shouldBe` want
 

--- a/core/lib/Cardano/Address/Script.hs
+++ b/core/lib/Cardano/Address/Script.hs
@@ -259,11 +259,17 @@ keyHashToText (KeyHash cred keyHash) = case cred of
 -- Bech32 encoded text with one of following hrp:
 -- - `addr_shared_vkh`
 -- - `stake_shared_vkh`
+-- - `addr_vkh`
+-- - `stake_vkh`
 -- - `policy_vkh`
 -- - `addr_shared_vk`
 -- - `stake_shared_vk`
+-- - `addr_vk`
+-- - `stake_vk`
 -- - `addr_shared_xvk`
 -- - `stake_shared_xvk`
+-- - `addr_xvk`
+-- - `stake_xvk`
 -- - `policy_vk`
 -- - `policy_xvk`
 -- Raw keys will be hashed on the fly, whereas hash that are directly
@@ -282,11 +288,17 @@ keyHashFromText txt = do
     convertBytes hrp bytes
         | hrp == CIP5.addr_shared_vkh  = Just (Payment, bytes)
         | hrp == CIP5.stake_shared_vkh = Just (Delegation, bytes)
+        | hrp == CIP5.addr_vkh  = Just (Payment, bytes)
+        | hrp == CIP5.stake_vkh = Just (Delegation, bytes)
         | hrp == CIP5.policy_vkh       = Just (Policy, bytes)
         | hrp == CIP5.addr_shared_vk   = Just (Payment, hashCredential bytes)
+        | hrp == CIP5.addr_vk   = Just (Payment, hashCredential bytes)
         | hrp == CIP5.addr_shared_xvk  = Just (Payment, hashCredential $ BS.take 32 bytes)
+        | hrp == CIP5.addr_xvk  = Just (Payment, hashCredential $ BS.take 32 bytes)
         | hrp == CIP5.stake_shared_vk  = Just (Delegation, hashCredential bytes)
+        | hrp == CIP5.stake_vk  = Just (Delegation, hashCredential bytes)
         | hrp == CIP5.stake_shared_xvk = Just (Delegation, hashCredential $ BS.take 32 bytes)
+        | hrp == CIP5.stake_xvk = Just (Delegation, hashCredential $ BS.take 32 bytes)
         | hrp == CIP5.policy_vk        = Just (Policy, hashCredential bytes)
         | hrp == CIP5.policy_xvk       = Just (Policy, hashCredential $ BS.take 32 bytes)
         | otherwise                    = Nothing

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -737,6 +737,7 @@ data instance Credential 'PaymentK where
 
 data instance Credential 'DelegationK where
     DelegationFromKey :: Shelley 'DelegationK XPub -> Credential 'DelegationK
+    DelegationFromKeyHash :: KeyHash -> Credential 'DelegationK
     DelegationFromScript :: ScriptHash -> Credential 'DelegationK
     DelegationFromPointer :: ChainPointer -> Credential 'DelegationK
     deriving Show
@@ -816,6 +817,15 @@ stakeAddress discrimination = \case
             discrimination
             (hashCredential . xpubPublicKey . getKey $ keyPub)
 
+    DelegationFromKeyHash (KeyHash Delegation verKeyHash) ->
+        Right $ constructPayload
+            (RewardAccount CredentialFromKey)
+            discrimination
+            verKeyHash
+
+    DelegationFromKeyHash (KeyHash keyrole _) ->
+        Left $ ErrStakeAddressFromKeyHash keyrole
+
     DelegationFromScript (ScriptHash bytes) ->
         Right $ constructPayload
             (RewardAccount CredentialFromScript)
@@ -831,6 +841,7 @@ stakeAddress discrimination = \case
 -- @since 3.0.0
 data ErrInvalidStakeAddress
     = ErrStakeAddressFromPointer
+    | ErrStakeAddressFromKeyHash KeyRole
     deriving (Generic, Show, Eq)
 
 -- | Extend an existing payment 'Address' to make it a delegation address.
@@ -865,6 +876,17 @@ extendAddress addr infoStakeReference = do
                 putWord8 $ fstByte .&. 0b00011111
                 putByteString rest
                 putByteString . hashCredential . xpubPublicKey . getKey $ delegationKey
+        DelegationFromKeyHash (KeyHash Delegation keyhash) -> do
+            pure $ unsafeMkAddress $ BL.toStrict $ runPut $ do
+                -- 0b01100000 .&. 0b00011111 = 0
+                -- 0b01110000 .&. 0b00011111 = 16
+                putWord8 $ fstByte .&. 0b00011111
+                putByteString rest
+                putByteString keyhash
+        DelegationFromKeyHash (KeyHash keyrole _) -> do
+            Left $ ErrInvalidKeyHashType $
+                "Delegation part can only be constructed from delegation key hash. "
+                <> "Key hash of " <> show keyrole <> " was used."
 
         -- base address: keyhash28,scripthash32    : 00100000 -> 32
         -- base address: scripthash32,scripthash32 : 00110000 -> 48
@@ -897,6 +919,7 @@ extendAddress addr infoStakeReference = do
 data ErrExtendAddress
     = ErrInvalidAddressStyle String
     | ErrInvalidAddressType String
+    | ErrInvalidKeyHashType String
     deriving (Show)
 
 --

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -113,7 +113,7 @@ import Cardano.Address.Derivation
 import Cardano.Address.Internal
     ( WithErrorMessage (..), orElse )
 import Cardano.Address.Script
-    ( ScriptHash (..), KeyHash (..), KeyRole (..) )
+    ( KeyHash (..), KeyRole (..), ScriptHash (..) )
 import Cardano.Mnemonic
     ( SomeMnemonic, someMnemonicToBytes )
 import Codec.Binary.Encoding

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -212,6 +212,20 @@ spec = do
             ,  expectedAddr =
                     "018a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
             }
+        goldenTestBaseAddressStakeFromKeyHash GoldenTestBaseAddress
+            {  verKeyPayment = "1a2a3a4a5a6a7a8a"
+            ,  verKeyStake = "1c2c3c4c5c6c7c8c"
+            ,  netTag = 0
+            ,  expectedAddr =
+                    "008a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
+            }
+        goldenTestBaseAddressStakeFromKeyHash GoldenTestBaseAddress
+            {  verKeyPayment = "1a2a3a4a5a6a7a8a"
+            ,  verKeyStake = "1c2c3c4c5c6c7c8c"
+            ,  netTag = 1
+            ,  expectedAddr =
+                    "018a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
+            }
 
     describe "Test vectors" $ do
         testVectors
@@ -418,6 +432,27 @@ goldenTestBaseAddressPayFromKeyHash GoldenTestBaseAddress{..} =
                 delegationAddress tag (PaymentFromKeyHash keyHash)
                 (DelegationFromKey stakeXPub)
         baseAddrPayFromKey `shouldBe` baseAddrPayFromKeyHash
+
+goldenTestBaseAddressStakeFromKeyHash :: GoldenTestBaseAddress -> SpecWith ()
+goldenTestBaseAddressStakeFromKeyHash GoldenTestBaseAddress{..} =
+    it ("base address for networkId " <> show netTag) $ do
+        let paymentBs = b16encode $ T.append verKeyPayment verKeyPayment
+        let (Just xPub1) = xpubFromBytes paymentBs
+        let addrXPub = liftXPub xPub1 :: Shelley 'PaymentK XPub
+        let stakeBs = b16encode $ T.append verKeyStake verKeyStake
+        let (Just xPub2) = xpubFromBytes stakeBs
+        let stakeXPub = liftXPub xPub2 :: Shelley 'DelegationK XPub
+        let (Right tag) = mkNetworkDiscriminant netTag
+        let baseAddrStakeFromKey =
+                delegationAddress tag (PaymentFromKey addrXPub)
+                (DelegationFromKey stakeXPub)
+        let keyHashDigest = hashCredential $ BS.take 32 stakeBs
+        let keyHash = KeyHash Delegation keyHashDigest
+        let baseAddrStakeFromKeyHash =
+                delegationAddress tag (PaymentFromKey addrXPub)
+                (DelegationFromKeyHash keyHash)
+        baseAddrStakeFromKey `shouldBe` baseAddrStakeFromKeyHash
+
 
 data TestVector = TestVector
     {

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -226,6 +226,20 @@ spec = do
             ,  expectedAddr =
                     "018a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
             }
+        goldenTestBaseAddressBothFromKeyHash GoldenTestBaseAddress
+            {  verKeyPayment = "1a2a3a4a5a6a7a8a"
+            ,  verKeyStake = "1c2c3c4c5c6c7c8c"
+            ,  netTag = 0
+            ,  expectedAddr =
+                    "008a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
+            }
+        goldenTestBaseAddressBothFromKeyHash GoldenTestBaseAddress
+            {  verKeyPayment = "1a2a3a4a5a6a7a8a"
+            ,  verKeyStake = "1c2c3c4c5c6c7c8c"
+            ,  netTag = 1
+            ,  expectedAddr =
+                    "018a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
+            }
 
     describe "Test vectors" $ do
         testVectors
@@ -452,6 +466,28 @@ goldenTestBaseAddressStakeFromKeyHash GoldenTestBaseAddress{..} =
                 delegationAddress tag (PaymentFromKey addrXPub)
                 (DelegationFromKeyHash keyHash)
         baseAddrStakeFromKey `shouldBe` baseAddrStakeFromKeyHash
+
+goldenTestBaseAddressBothFromKeyHash :: GoldenTestBaseAddress -> SpecWith ()
+goldenTestBaseAddressBothFromKeyHash GoldenTestBaseAddress{..} =
+    it ("base address for networkId " <> show netTag) $ do
+        let paymentBs = b16encode $ T.append verKeyPayment verKeyPayment
+        let (Just xPub1) = xpubFromBytes paymentBs
+        let addrXPub = liftXPub xPub1 :: Shelley 'PaymentK XPub
+        let stakeBs = b16encode $ T.append verKeyStake verKeyStake
+        let (Just xPub2) = xpubFromBytes stakeBs
+        let stakeXPub = liftXPub xPub2 :: Shelley 'DelegationK XPub
+        let (Right tag) = mkNetworkDiscriminant netTag
+        let baseAddrBothFromKey =
+                delegationAddress tag (PaymentFromKey addrXPub)
+                (DelegationFromKey stakeXPub)
+        let paymentKeyHashDigest = hashCredential $ BS.take 32 paymentBs
+        let paymentKeyHash = KeyHash Payment paymentKeyHashDigest
+        let stakeKeyHashDigest = hashCredential $ BS.take 32 stakeBs
+        let stakeKeyHash = KeyHash Delegation stakeKeyHashDigest
+        let baseAddrBothFromKeyHash =
+                delegationAddress tag (PaymentFromKeyHash paymentKeyHash)
+                (DelegationFromKeyHash stakeKeyHash)
+        baseAddrBothFromKey `shouldBe` baseAddrBothFromKeyHash
 
 
 data TestVector = TestVector


### PR DESCRIPTION
[ADP-1985](https://input-output.atlassian.net/browse/ADP-1985)

PR extends possible bech32 prefixes possible for key hashes, now also non shared ones also.
Also `Credential` is extended and can be constructed from key hash, for both payment and delegation credential.
`PaymentFromKeyHash` and `DelegationFromKeyHash` were added. Thanks to that payment and base address, as well as reward address now can be constructed from key hashes. The new functionality was checked on golden tests. Also proper support in command lines was added, along with testing and documentation.