### PR TITLE
Bump hw-aeson to v0.1.6.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,7 +31,7 @@ source-repository-package
 
 -- TODO This was patched to work with aeson 1 & 2 with the help of hw-aeson.
 -- Once downstream projects are all upgraded to work with aeson-2, they can
--- be changed to work strictly with aeson 2 only. 
+-- be changed to work strictly with aeson 2 only.
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/hjsonpointer
@@ -55,8 +55,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/haskell-works/hw-aeson
-    tag: d99d2f3e39a287607418ae605b132a3deb2b753f
-    --sha256: 1vxqcwjg9q37wbwi27y9ba5163lzfz51f1swbi0rp681yg63zvn4
+    tag: 5b4613379830ce06b167301c5ecb3c49c7d7eb4b
+    --sha256: 0i0f7rnbr49rk59fzap9433b00hklgiq26aq9vqgmw9dmafv43i3
 
 -- Relax overly strict bounds in hjsonschema and hjsonpointer
 allow-newer:

--- a/core/lib/Cardano/Address/Script.hs
+++ b/core/lib/Cardano/Address/Script.hs
@@ -801,9 +801,11 @@ instance FromJSON ScriptTemplate where
         ScriptTemplate <$> (Map.fromList <$> cosigners') <*> template'
       where
         parseCosignerPairs = withObject "Cosigner pairs" $ \o ->
-            case JM.toList o of
+            case toList o of
                 [] -> fail "Cosigners object array should not be empty"
                 cs -> for (reverse cs) $ \(numTxt, str) -> do
                     cosigner' <- parseJSON @Cosigner (String (J.keyToText numTxt))
                     xpub <- parseXPub str
                     pure (cosigner', xpub)
+
+        toList = JM.foldlWithKey' (\acc k v -> (k,v):acc) []

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ extra-deps:
   commit: 1546af7fc267d5eea805ef223dd2b59ac120b784
 
 - git: https://github.com/haskell-works/hw-aeson
-  commit: d99d2f3e39a287607418ae605b132a3deb2b753f
+  commit: 5b4613379830ce06b167301c5ecb3c49c7d7eb4b
 
 - string-interpolate-0.3.0.2
 - hspec-golden-0.1.0.3


### PR DESCRIPTION
- cardano-node 1.35.3 is using hw-aeson v0.1.6.0.
- v0.1.6.0 of hw-aeson changes the API such that it no longer exposes "toList",
  but only when compiled with versions of aeson > 2.0.0.0.
  - This can be a bit confusing, as cardano-addresses uses aeson < 2.0.0.0 by
  default.
- Change how cardano-addresses uses the hw-aeson API to workaround this breakage
  in the API.
  - Simply re-write "toList" in terms of "foldlWithKey'".
  - Both `toList` and `foldlWithKey'` have O(n) complexity.