### PR TITLE
Enable using script and pub keys in credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Let's generate extended root private key for shared style:
 
 ``` console
 $ cardano-address key from-recovery-phrase Shared < phrase.prv > root_shared.xsk
+root_shared_xsk1hqzfzrgskgnpwskxxrv5khs7ess82ecy8za9l5ef7e0afd2849p3zryje8chk39nxtva0sww5me3pzkej4rvd5cae3q3v8eu7556n6pdrp4fdu8nsglynpmcppxxvfdyzdz5gfq3fefjepxhvqspmuyvmvzteqlc
 ```
 
 Now generate payment verification key (`role=0` is used). Please note that purpose `1854H` is used for multisig.
@@ -324,6 +325,10 @@ stake_shared_vk18a8z5dcrlwene88n84j6dm9yvj5rt296fjtresqnunmacetdcymquyq43z
 We consider `addr_shared.1.vk` and `addr_shared.2.vk` obtained like `addr_shared.vk` but by replacing the final index by `1` and `2` respectively.
 
 ```console
+$ cardano-address key child 1854H/1815H/0H/0/1 < root_shared.xsk | cardano-address key public --without-chain-code > addr_shared.1.vk
+addr_shared_vk1wgj79fxw2vmxkp85g88nhwlflkxevd77t6wy0nsktn2f663wdcmqcd4fp3
+$ cardano-address key child 1854H/1815H/0H/0/2 < root_shared.xsk | cardano-address key public --without-chain-code > addr_shared.2.vk
+addr_shared_vk1jthguyss2vffmszq63xsmxlpc9elxnvdyaqk7susl4sppp2s9xqsuszh44
 $ cardano-address script hash "all [$(cat addr_shared.1.vk), $(cat addr_shared.2.vk)]" > script.hash
 script1gr69m385thgvkrtspk73zmkwk537wxyxuevs2u9cukglvtlkz4k
 ```
@@ -333,7 +338,11 @@ This script requires the signature from both signing keys corresponding to `shar
 We can also use extended verification, eiher payment or delegation, keys. They can be obtained as the non-extended ones by using `--with-chain-code` option rather than `--without-chain-option` as above. They will give rise to the same script hash as for verification keys chain code is stripped upon calculation.
 
 ```console
-$ cardano-address script hash "any [$(cat addr_shared.1.xvk), $(cat addr_shared.2.xvk)]"
+$ cardano-address key child 1854H/1815H/0H/0/1 < root_shared.xsk | cardano-address key public --with-chain-code > addr_shared.1.xvk
+addr_shared_xvk1wgj79fxw2vmxkp85g88nhwlflkxevd77t6wy0nsktn2f663wdcmqhlfft3dn0qcn6q99dvlfl2ws5duy6w65zks5jgufe60fg839sysavl5pc
+$ cardano-address key child 1854H/1815H/0H/0/2 < root_shared.xsk | cardano-address key public --with-chain-code > addr_shared.2.xvk
+addr_shared_xvk1jthguyss2vffmszq63xsmxlpc9elxnvdyaqk7susl4sppp2s9xq3zegcxtslhpghmadrlvsphssfjqp3mxg9gca27e35wpu43lqjqnsmjvxuw
+$ cardano-address script hash "all [$(cat addr_shared.1.xvk), $(cat addr_shared.2.xvk)]"
 script1gr69m385thgvkrtspk73zmkwk537wxyxuevs2u9cukglvtlkz4k
 ```
 
@@ -350,6 +359,7 @@ script13uf3fz3ts5srpjc5zcfe977uvnyvp36wcvxuudryegz0zpjlx6a
 
 ```console
 $  cardano-address script hash "all [$(cat addr_shared.1.xvk), $(cat addr_shared.2.xvk), active_from 100, active_until 120]"
+script1nugjzwfs2t9htl7s3dv9ajnd5us8pctpa8aj4ank8dnd6d6unul
 ```
 </details>
 
@@ -383,7 +393,16 @@ $  cardano-address script preimage "all [addr_shared_vkh1zxt0uvrza94h3hv4jpv0ttd
 
 ```console
 $ cardano-address address payment --network-tag testnet < script.hash > script.addr
-addr_test1wqqggtajwkxjgf58v452jz6jl87lt32w3mhez5hd7xz6hugp80tta
+addr_test1wpq0ghwy73wapjcdwqxm6ytwe66j8eccsmn9jptshrjerashp7y82
+```
+</details>
+
+<details>
+  <summary>How to generate a payment script address from a script (<strong>script.addr</strong>)</summary>
+
+```console
+$ cardano-address address payment --network-tag testnet "all [$(cat addr_shared.1.xvk), $(cat addr_shared.2.xvk)]"  > script.addr
+addr_test1wpq0ghwy73wapjcdwqxm6ytwe66j8eccsmn9jptshrjerashp7y82
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -164,13 +164,26 @@ $ cardano-address key hash --hex < addr.xvk
 
 
 <details>
-  <summary>How to generate a payment address from a payment key (<strong>payment.addr</strong>)</summary>
+  <summary>How to generate a payment address from an extended payment key (<strong>payment.addr</strong>)</summary>
 
 ```console
 $ cardano-address address payment --network-tag testnet < addr.xvk > payment.addr
 addr_test1vp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f7guscp6v
 ```
 </details>
+
+
+<details>
+  <summary>How to generate a payment address from a non-extended payment key (<strong>payment.addr</strong>)</summary>
+
+```console
+$ cardano-address key child 1852H/1815H/0H/0/0 < root.xsk | cardano-address key public --without-chain-code > addr.vk
+addr_vk1grvg8qzmkmw2n0dm4pd0h3j4dv6yglyammyp733eyj629dc3z28qwq4y73
+$ cardano-address address payment --network-tag testnet < addr.vk > payment.addr
+addr_test1vp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f7guscp6v
+```
+</details>
+
 
 <details>
   <summary>How to generate a payment address from a payment key hash (<strong>payment.addr</strong>)</summary>

--- a/README.md
+++ b/README.md
@@ -137,11 +137,22 @@ addr_xvk1grvg8qzmkmw2n0dm4pd0h3j4dv6yglyammyp733eyj629dc3z28v6wk22nfmru6xz0vl2s3
 </details>
 
 <details>
-  <summary>How to generate a stake verification key (<strong>stake.xvk</strong>)</summary>
+  <summary>How to generate an extended stake verification key (<strong>stake.xvk</strong>)</summary>
 
 ```console
 $ cardano-address key child 1852H/1815H/0H/2/0 < root.xsk | cardano-address key public --with-chain-code > stake.xvk
 stake_xvk1658atzttunamzn80204khrg0qfdk5nvmrutlmmpg7xlsyaggwa7h9z4smmeqsvs67qhyqmc2lqa0vy36rf2la74ym8a5p93zp4qtpuq6ky3ve
+```
+
+> :information_source: The last segment in the path is the key index and can be incremented up to `2^31-1` to derive more keys.
+</details>
+
+<details>
+  <summary>How to generate a non-extended stake verification key (<strong>stake.vk</strong>)</summary>
+
+```console
+$ cardano-address key child 1852H/1815H/0H/2/0 < root.xsk | cardano-address key public --without-chain-code > stake.vk
+stake_vk1658atzttunamzn80204khrg0qfdk5nvmrutlmmpg7xlsyaggwa7sg87an2
 ```
 
 > :information_source: The last segment in the path is the key index and can be incremented up to `2^31-1` to derive more keys.
@@ -229,10 +240,19 @@ addr_test1qp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f70k6tew7wrnx0s4465nx05ajz
 </details>
 
 <details>
-  <summary>How to generate a stake address from a stake key (<strong>stake.addr</strong>)</summary>
+  <summary>How to generate a stake address from an extended stake key (<strong>stake.addr</strong>)</summary>
 
 ```console
 $ cardano-address address stake --network-tag testnet < stake.xvk > stake.addr
+stake_test1urmd9uh08pen8c26a2fn86weprjh52638mrdwc5gfac2u2s25zpat
+```
+</details>
+
+<details>
+  <summary>How to generate a stake address from a non-extended stake key (<strong>stake.addr</strong>)</summary>
+
+```console
+$ cardano-address address stake --network-tag testnet < stake.vk > stake.addr
 stake_test1urmd9uh08pen8c26a2fn86weprjh52638mrdwc5gfac2u2s25zpat
 ```
 </details>
@@ -417,6 +437,32 @@ addr_test1xpq0ghwy73wapjcdwqxm6ytwe66j8eccsmn9jptshrjera5lzysnjvzjed6ll5yttp0v5m
 ```
 </details>
 
+<details>
+  <summary>How to generate a delegated payment address, i.e. base address, from a script (<strong>base.addr</strong>)</summary>
+
+```console
+$ cardano-address address delegation "all [$(cat addr_shared.1.xvk), $(cat addr_shared.2.xvk), active_from 100, active_until 120]" < script.addr > base.addr
+addr_test1xpq0ghwy73wapjcdwqxm6ytwe66j8eccsmn9jptshrjera5lzysnjvzjed6ll5yttp0v5md8ypcwzc0flv40va3mvmwsl7grs3
+```
+</details>
+
+<details>
+  <summary>How to generate a stake address from a script hash (<strong>stake.addr</strong>)</summary>
+
+```console
+$ cardano-address address stake --network-tag testnet < script.stake.hash > stake.addr
+stake_test17z03zgfexpfvka0l6z94shk2dknjqu8pv85lk2hkwcakdhgx52yaj
+```
+</details>
+
+<details>
+  <summary>How to generate a stake address from a script (<strong>stake.addr</strong>)</summary>
+
+```console
+$ cardano-address address stake --network-tag testnet "all [$(cat addr_shared.1.xvk), $(cat addr_shared.2.xvk), active_from 100, active_until 120]" > stake.addr
+stake_test17z03zgfexpfvka0l6z94shk2dknjqu8pv85lk2hkwcakdhgx52yaj
+```
+</details>
 
 <details>
   <summary>Correspondence between keys in cardano-addresses and cardano-cli (<strong>key.xsk key.xvk key.vk key.hash</strong>)</summary>

--- a/README.md
+++ b/README.md
@@ -198,10 +198,21 @@ addr_test1vp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f7guscp6v
 
 
 <details>
-  <summary>How to generate a delegated payment address, i.e. base address, from a stake key (<strong>base.addr</strong>)</summary>
+  <summary>How to generate a delegated payment address, i.e. base address, from an extended stake key (<strong>base.addr</strong>)</summary>
 
 ```console
 $ cardano-address address delegation $(cat stake.xvk) < payment.addr > base.addr
+addr_test1qp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f70k6tew7wrnx0s4465nx05ajz890g44z0kx6a3gsnms4c4qq8ve0n
+```
+</details>
+
+<details>
+  <summary>How to generate a delegated payment address, i.e. base address, from a non-extended stake key (<strong>base.addr</strong>)</summary>
+
+```console
+$ cardano-address key child 1852H/1815H/0H/2/0 < root.xsk | cardano-address key public --without-chain-code > stake.vk
+stake_vk1658atzttunamzn80204khrg0qfdk5nvmrutlmmpg7xlsyaggwa7sg87an2
+$ cardano-address address delegation $(cat stake.vk) < payment.addr > base.addr
 addr_test1qp2fg770ddmqxxduasjsas39l5wwvwa04nj8ud95fde7f70k6tew7wrnx0s4465nx05ajz890g44z0kx6a3gsnms4c4qq8ve0n
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -407,6 +407,18 @@ addr_test1wpq0ghwy73wapjcdwqxm6ytwe66j8eccsmn9jptshrjerashp7y82
 </details>
 
 <details>
+  <summary>How to generate a delegated payment address, i.e. base address, from a script hash (<strong>base.addr</strong>)</summary>
+
+```console
+$ cardano-address script hash "all [$(cat addr_shared.1.xvk), $(cat addr_shared.2.xvk), active_from 100, active_until 120]" > script.stake.hash
+script1nugjzwfs2t9htl7s3dv9ajnd5us8pctpa8aj4ank8dnd6d6unul
+$ cardano-address address delegation $(cat script.stake.hash) < script.addr > base.addr
+addr_test1xpq0ghwy73wapjcdwqxm6ytwe66j8eccsmn9jptshrjera5lzysnjvzjed6ll5yttp0v5md8ypcwzc0flv40va3mvmwsl7grs3
+```
+</details>
+
+
+<details>
   <summary>Correspondence between keys in cardano-addresses and cardano-cli (<strong>key.xsk key.xvk key.vk key.hash</strong>)</summary>
 
 ```console

--- a/command-line/lib/Command/Address/Delegation.hs
+++ b/command-line/lib/Command/Address/Delegation.hs
@@ -65,8 +65,9 @@ mod liftCmd = command "delegation" $
             , indent 2 $ string "addr1qpj2d4dqzds5p3mmlu95v9pex2d72cdvyjh2u3dtj4yqesv27k..."
             ])
   where
+    msg = "An extended stake public key, anon-extended stake public key, a script or a script hash."
     parser = Cmd
-        <$> delegationCredentialArg "An extended stake public key or a script hash."
+        <$> delegationCredentialArg msg
 
 run :: Cmd -> IO ()
 run Cmd{credential} = do

--- a/command-line/lib/Command/Address/Delegation.hs
+++ b/command-line/lib/Command/Address/Delegation.hs
@@ -65,7 +65,7 @@ mod liftCmd = command "delegation" $
             , indent 2 $ string "addr1qpj2d4dqzds5p3mmlu95v9pex2d72cdvyjh2u3dtj4yqesv27k..."
             ])
   where
-    msg = "An extended stake public key, anon-extended stake public key, a script or a script hash."
+    msg = "An extended stake public key, a non-extended stake public key, a script or a script hash."
     parser = Cmd
         <$> delegationCredentialArg msg
 

--- a/command-line/lib/Command/Address/Payment.hs
+++ b/command-line/lib/Command/Address/Payment.hs
@@ -93,7 +93,7 @@ run Cmd{networkTag} = do
                 Nothing ->
                     fail "Couldn't convert bytes into script hash."
                 Just h  -> do
-                    let credential = PaymentFromScript h
+                    let credential = PaymentFromScriptHash h
                     pure $ Shelley.paymentAddress discriminant credential
 
         | hrp == CIP5.addr_vkh = do
@@ -109,5 +109,5 @@ run Cmd{networkTag} = do
                 Nothing  ->
                     fail "Couldn't convert bytes into extended public key."
                 Just key -> do
-                    let credential = PaymentFromKey $ Shelley.liftXPub key
+                    let credential = PaymentFromExtendedKey $ Shelley.liftXPub key
                     pure $ Shelley.paymentAddress discriminant credential

--- a/command-line/lib/Command/Address/Payment.hs
+++ b/command-line/lib/Command/Address/Payment.hs
@@ -19,17 +19,28 @@ import Cardano.Address
 import Cardano.Address.Derivation
     ( pubFromBytes, xpubFromBytes )
 import Cardano.Address.Script
-    ( KeyRole (..), keyHashFromBytes, scriptHashFromBytes )
+    ( KeyHash, KeyRole (..), Script, keyHashFromBytes, scriptHashFromBytes )
 import Cardano.Address.Style.Shelley
     ( Credential (..), shelleyTestnet )
 import Codec.Binary.Encoding
     ( AbstractEncoding (..) )
 import Options.Applicative
-    ( CommandFields, Mod, command, footerDoc, header, helper, info, progDesc )
+    ( CommandFields
+    , Mod
+    , command
+    , footerDoc
+    , header
+    , helper
+    , info
+    , optional
+    , progDesc
+    )
 import Options.Applicative.Discrimination
     ( NetworkTag (..), fromNetworkTag, networkTagOpt )
 import Options.Applicative.Help.Pretty
     ( bold, indent, string, vsep )
+import Options.Applicative.Script
+    ( scriptArg )
 import Options.Applicative.Style
     ( Style (..) )
 import System.IO
@@ -40,8 +51,9 @@ import System.IO.Extra
 import qualified Cardano.Address.Style.Shelley as Shelley
 import qualified Cardano.Codec.Bech32.Prefixes as CIP5
 
-newtype Cmd = Cmd
-    {  networkTag :: NetworkTag
+data Cmd = Cmd
+    { networkTag :: NetworkTag
+    , paymentScript :: Maybe (Script KeyHash)
     } deriving (Show)
 
 mod :: (Cmd -> parent) -> Mod CommandFields parent
@@ -65,12 +77,18 @@ mod liftCmd = command "payment" $
   where
     parser = Cmd
         <$> networkTagOpt Shelley
+        <*> optional scriptArg
 
 run :: Cmd -> IO ()
-run Cmd{networkTag} = do
+run Cmd{networkTag,paymentScript} = do
     discriminant <- fromNetworkTag networkTag
-    (hrp, bytes) <- hGetBech32 stdin allowedPrefixes
-    addr <- addressFromBytes discriminant bytes hrp
+    addr <- case paymentScript of
+        Just script -> do
+            let credential = PaymentFromScript script
+            pure $ Shelley.paymentAddress discriminant credential
+        Nothing -> do
+            (hrp, bytes) <- hGetBech32 stdin allowedPrefixes
+            addressFromBytes discriminant bytes hrp
     hPutBytes stdout (unAddress addr) (EBech32 addrHrp)
   where
     addrHrp

--- a/command-line/lib/Command/Address/Payment.hs
+++ b/command-line/lib/Command/Address/Payment.hs
@@ -17,7 +17,7 @@ import Prelude hiding
 import Cardano.Address
     ( unAddress )
 import Cardano.Address.Derivation
-    ( xpubFromBytes )
+    ( pubFromBytes, xpubFromBytes )
 import Cardano.Address.Script
     ( KeyRole (..), keyHashFromBytes, scriptHashFromBytes )
 import Cardano.Address.Style.Shelley
@@ -83,6 +83,7 @@ run Cmd{networkTag} = do
     -- this stage, so leaving this as an item for later.
     allowedPrefixes =
         [ CIP5.addr_xvk
+        , CIP5.addr_vk
         , CIP5.addr_vkh
         , CIP5.script
         ]
@@ -102,6 +103,14 @@ run Cmd{networkTag} = do
                     fail "Couldn't convert bytes into payment key hash."
                 Just keyhash -> do
                     let credential = PaymentFromKeyHash keyhash
+                    pure $ Shelley.paymentAddress discriminant credential
+
+        | hrp == CIP5.addr_vk = do
+            case pubFromBytes bytes of
+                Nothing  ->
+                    fail "Couldn't convert bytes into non-extended public key."
+                Just key -> do
+                    let credential = PaymentFromKey $ Shelley.liftPub key
                     pure $ Shelley.paymentAddress discriminant credential
 
         | otherwise = do

--- a/command-line/lib/Command/Address/Payment.hs
+++ b/command-line/lib/Command/Address/Payment.hs
@@ -77,10 +77,6 @@ run Cmd{networkTag} = do
         | networkTag == shelleyTestnet = CIP5.addr_test
         | otherwise = CIP5.addr
 
-    -- TODO: Also allow `XXX_vk` prefixes. We don't need the chain code to
-    -- construct a payment credential. This will however need some additional
-    -- abstraction over `xpubFromBytes` but I've done enough yake-shaving at
-    -- this stage, so leaving this as an item for later.
     allowedPrefixes =
         [ CIP5.addr_xvk
         , CIP5.addr_vk

--- a/command-line/lib/Command/Address/Reward.hs
+++ b/command-line/lib/Command/Address/Reward.hs
@@ -110,5 +110,5 @@ run Cmd{networkTag} = do
                 Nothing  ->
                     fail "Couldn't convert bytes into extended public key."
                 Just key -> do
-                    let credential = DelegationFromKey $ Shelley.liftXPub key
+                    let credential = DelegationFromExtendedKey $ Shelley.liftXPub key
                     pure $ unsafeFromRight $ Shelley.stakeAddress discriminant credential

--- a/command-line/lib/Command/Address/Reward.hs
+++ b/command-line/lib/Command/Address/Reward.hs
@@ -94,7 +94,7 @@ run Cmd{networkTag} = do
                 Nothing ->
                     fail "Couldn't convert bytes into script hash."
                 Just h  -> do
-                    let credential = DelegationFromScript h
+                    let credential = DelegationFromScriptHash h
                     pure $ unsafeFromRight $ Shelley.stakeAddress discriminant credential
 
         | hrp == CIP5.stake_vkh = do

--- a/command-line/lib/Options/Applicative/Credential.hs
+++ b/command-line/lib/Options/Applicative/Credential.hs
@@ -41,7 +41,7 @@ delegationCredentialArg helpDoc = argument (eitherReader reader) $ mempty
        `orElse`
        (DelegationFromKeyHash <$> keyhashReader (Delegation, allowedPrefixesForKeyHash) str)
        `orElse`
-       (DelegationFromScript <$> scriptHashReader str)
+       (DelegationFromScriptHash <$> scriptHashReader str)
        `orElse`
        Left "Couldn't parse delegation credentials. Neither a public key, a public key hash nor a script hash."
 

--- a/command-line/lib/Options/Applicative/Credential.hs
+++ b/command-line/lib/Options/Applicative/Credential.hs
@@ -32,7 +32,7 @@ import qualified Cardano.Codec.Bech32.Prefixes as CIP5
 
 delegationCredentialArg  :: String -> Parser (Credential 'DelegationK)
 delegationCredentialArg helpDoc = argument (eitherReader reader) $ mempty
-    <> metavar "KEY || KEY HASH || SCRIPT HASH"
+    <> metavar "EXTENDED KEY || NON-EXTENDED KEY || KEY HASH || SCRIPT HASH"
     <> help helpDoc
   where
     reader :: String -> Either String (Credential 'DelegationK)
@@ -45,7 +45,12 @@ delegationCredentialArg helpDoc = argument (eitherReader reader) $ mempty
        `orElse`
        (DelegationFromScriptHash <$> scriptHashReader str)
        `orElse`
-       Left "Couldn't parse delegation credentials. Neither a public key, a public key hash nor a script hash."
+       Left errMsg
+
+    errMsg = mconcat
+        [ "Couldn't parse delegation credentials. Neither an extended public key, "
+        , "a non-extended public key, a public key hash nor a script hash."
+        ]
 
     allowedPrefixesForPub =
         [ CIP5.stake_vk

--- a/command-line/lib/Options/Applicative/Credential.hs
+++ b/command-line/lib/Options/Applicative/Credential.hs
@@ -22,7 +22,7 @@ import Options.Applicative
 import Options.Applicative.Derivation
     ( keyhashReader, pubReader, xpubReader )
 import Options.Applicative.Script
-    ( scriptHashReader )
+    ( scriptHashReader, scriptReader )
 
 import qualified Cardano.Codec.Bech32.Prefixes as CIP5
 
@@ -32,7 +32,7 @@ import qualified Cardano.Codec.Bech32.Prefixes as CIP5
 
 delegationCredentialArg  :: String -> Parser (Credential 'DelegationK)
 delegationCredentialArg helpDoc = argument (eitherReader reader) $ mempty
-    <> metavar "EXTENDED KEY || NON-EXTENDED KEY || KEY HASH || SCRIPT HASH"
+    <> metavar "EXTENDED KEY || NON-EXTENDED KEY || KEY HASH || SCRIPT || SCRIPT HASH"
     <> help helpDoc
   where
     reader :: String -> Either String (Credential 'DelegationK)
@@ -45,11 +45,13 @@ delegationCredentialArg helpDoc = argument (eitherReader reader) $ mempty
        `orElse`
        (DelegationFromScriptHash <$> scriptHashReader str)
        `orElse`
+       (DelegationFromScript <$> scriptReader str)
+       `orElse`
        Left errMsg
 
     errMsg = mconcat
         [ "Couldn't parse delegation credentials. Neither an extended public key, "
-        , "a non-extended public key, a public key hash nor a script hash."
+        , "a non-extended public key, a public key hash, a script nor a script hash."
         ]
 
     allowedPrefixesForPub =

--- a/command-line/lib/Options/Applicative/Credential.hs
+++ b/command-line/lib/Options/Applicative/Credential.hs
@@ -37,7 +37,7 @@ delegationCredentialArg helpDoc = argument (eitherReader reader) $ mempty
   where
     reader :: String -> Either String (Credential 'DelegationK)
     reader str =
-       (DelegationFromKey . liftXPub <$> xpubReader allowedPrefixesForXPub str)
+       (DelegationFromExtendedKey . liftXPub <$> xpubReader allowedPrefixesForXPub str)
        `orElse`
        (DelegationFromKeyHash <$> keyhashReader (Delegation, allowedPrefixesForKeyHash) str)
        `orElse`

--- a/command-line/lib/Options/Applicative/Derivation.hs
+++ b/command-line/lib/Options/Applicative/Derivation.hs
@@ -26,11 +26,12 @@ module Options.Applicative.Derivation
     , derivationIndexToString
     , derivationIndexFromString
 
-    -- * XPub / XPrv / KeyHash
+    -- * XPub / Pub / XPrv / KeyHash
     , xpubReader
     , xpubOpt
     , xpubArg
     , keyhashReader
+    , pubReader
 
     -- * Internal
     , bech32Reader
@@ -39,7 +40,14 @@ module Options.Applicative.Derivation
 import Prelude
 
 import Cardano.Address.Derivation
-    ( DerivationType (..), Index, XPub, wholeDomainIndex, xpubFromBytes )
+    ( DerivationType (..)
+    , Index
+    , Pub
+    , XPub
+    , pubFromBytes
+    , wholeDomainIndex
+    , xpubFromBytes
+    )
 import Cardano.Address.Script
     ( KeyHash (..), KeyRole (..), keyHashFromBytes )
 import Codec.Binary.Bech32
@@ -189,7 +197,7 @@ derivationIndexToString ix_@(DerivationIndex ix)
     ix' = fromIntegral ix - indexToInteger firstHardened
 
 --
--- XPub / XPrv
+-- XPub / Pub / XPrv
 --
 
 xpubReader :: [HumanReadablePart] -> String -> Either String XPub
@@ -199,6 +207,14 @@ xpubReader allowedPrefixes str = do
         Just xpub -> pure xpub
         Nothing   -> Left
             "Failed to convert bytes into a valid extended public key."
+
+pubReader :: [HumanReadablePart] -> String -> Either String Pub
+pubReader allowedPrefixes str = do
+    (_hrp, bytes) <- bech32Reader allowedPrefixes str
+    case pubFromBytes bytes of
+        Just pub -> pure pub
+        Nothing   -> Left
+            "Failed to convert bytes into a valid non-extended public key."
 
 xpubOpt :: [HumanReadablePart] -> String -> String -> Parser XPub
 xpubOpt allowedPrefixes name helpDoc =

--- a/command-line/test/Command/Address/DelegationSpec.hs
+++ b/command-line/test/Command/Address/DelegationSpec.hs
@@ -13,12 +13,22 @@ import Test.Utils
 
 spec :: Spec
 spec = describeCmd [ "address", "delegation" ] $ do
-    specFromKey defaultPhrase "1852H/1815H/0H/2/0"
+    specFromExtendedKey defaultPhrase "1852H/1815H/0H/2/0"
         defaultAddrMainnet
         "addr1q9therz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwvxwdrt\
         \70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qdqhgvu"
 
-    specFromKey defaultPhrase "1852H/1815H/0H/2/0"
+    specFromExtendedKey defaultPhrase "1852H/1815H/0H/2/0"
+        defaultAddrTestnet
+        "addr_test1qptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwv\
+        \xwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwk2gqr"
+
+    specFromNonextendedKey defaultPhrase "1852H/1815H/0H/2/0"
+        defaultAddrMainnet
+        "addr1q9therz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwvxwdrt\
+        \70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qdqhgvu"
+
+    specFromNonextendedKey defaultPhrase "1852H/1815H/0H/2/0"
         defaultAddrTestnet
         "addr_test1qptherz8fgux9ywdysrcpaclznyyvl23l2zfcery3f4m9qwv\
         \xwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwk2gqr"
@@ -58,11 +68,19 @@ spec = describeCmd [ "address", "delegation" ] $ do
     specInvalidXPub
         "stake_xvk1qfqcf4tp4ensj5qypqs640rt06pe5x7v2eul00c7rakzzvsakw3caelfuh6cg6nrkdv9y2ctkeu"
 
-specFromKey :: [String] -> String -> String -> String -> SpecWith ()
-specFromKey phrase path addr want = it ("delegation from key " <> want) $ do
+specFromExtendedKey :: [String] -> String -> String -> String -> SpecWith ()
+specFromExtendedKey phrase path addr want = it ("delegation from key " <> want) $ do
     stakeKey <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
        >>= cli [ "key", "child", path ]
        >>= cli [ "key", "public", "--with-chain-code" ]
+    out <- cli [ "address", "delegation", stakeKey ] addr
+    out `shouldBe` want
+
+specFromNonextendedKey :: [String] -> String -> String -> String -> SpecWith ()
+specFromNonextendedKey phrase path addr want = it ("delegation from key " <> want) $ do
+    stakeKey <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
+       >>= cli [ "key", "child", path ]
+       >>= cli [ "key", "public", "--without-chain-code" ]
     out <- cli [ "address", "delegation", stakeKey ] addr
     out `shouldBe` want
 

--- a/command-line/test/Command/Address/PaymentSpec.hs
+++ b/command-line/test/Command/Address/PaymentSpec.hs
@@ -13,16 +13,28 @@ import Test.Utils
 
 spec :: Spec
 spec = describeCmd [ "address", "payment" ] $ do
-    specShelley defaultPhrase "1852H/1815H/0H/0/0" "0"
+    specShelleyFromXPub defaultPhrase "1852H/1815H/0H/0/0" "0"
         "addr_test1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg57c2qv"
 
-    specShelley defaultPhrase "1852H/1815H/0H/0/0" "3"
+    specShelleyFromXPub defaultPhrase "1852H/1815H/0H/0/0" "3"
         "addr1vdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0m9a08"
 
-    specShelley defaultPhrase "1852H/1815H/0H/0/0" "testnet"
+    specShelleyFromXPub defaultPhrase "1852H/1815H/0H/0/0" "testnet"
         "addr_test1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg57c2qv"
 
-    specShelley defaultPhrase "1852H/1815H/0H/0/0" "mainnet"
+    specShelleyFromXPub defaultPhrase "1852H/1815H/0H/0/0" "mainnet"
+        "addr1v9u5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0kvk0f"
+
+    specShelleyFromPub defaultPhrase "1852H/1815H/0H/0/0" "0"
+        "addr_test1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg57c2qv"
+
+    specShelleyFromPub defaultPhrase "1852H/1815H/0H/0/0" "3"
+        "addr1vdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0m9a08"
+
+    specShelleyFromPub defaultPhrase "1852H/1815H/0H/0/0" "testnet"
+        "addr_test1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg57c2qv"
+
+    specShelleyFromPub defaultPhrase "1852H/1815H/0H/0/0" "mainnet"
         "addr1v9u5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0kvk0f"
 
     specShelleyFromKeyHash defaultPhrase "1852H/1815H/0H/0/0" "0"
@@ -42,11 +54,19 @@ spec = describeCmd [ "address", "payment" ] $ do
     specInvalidNetwork "42"
     specInvalidNetwork "staging"
 
-specShelley :: [String] -> String -> String -> String -> SpecWith ()
-specShelley phrase path networkTag want = it ("golden shelley (payment) " <> path) $ do
+specShelleyFromXPub :: [String] -> String -> String -> String -> SpecWith ()
+specShelleyFromXPub phrase path networkTag want = it ("golden shelley (payment) " <> path) $ do
     out <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
        >>= cli [ "key", "child", path ]
        >>= cli [ "key", "public", "--with-chain-code" ]
+       >>= cli [ "address", "payment", "--network-tag", networkTag ]
+    out `shouldBe` want
+
+specShelleyFromPub :: [String] -> String -> String -> String -> SpecWith ()
+specShelleyFromPub phrase path networkTag want = it ("golden shelley (payment) " <> path) $ do
+    out <- cli [ "key", "from-recovery-phrase", "shelley" ] (unwords phrase)
+       >>= cli [ "key", "child", path ]
+       >>= cli [ "key", "public", "--without-chain-code" ]
        >>= cli [ "address", "payment", "--network-tag", networkTag ]
     out `shouldBe` want
 

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -46,6 +46,12 @@ module Cardano.Address.Derivation
     , xpubPublicKey
     , xpubChainCode
 
+    -- ** Pub
+    , Pub
+    , pubFromBytes
+    , pubToBytes
+    , xpubToPub
+
     -- ** XSignature
     , XSignature
     , sign
@@ -173,6 +179,37 @@ xpubPublicKey (CC.XPub pub _cc) = pub
 -- @since 2.0.0
 xpubChainCode :: XPub -> ByteString
 xpubChainCode (CC.XPub _pub (CC.ChainCode cc)) = cc
+
+-- | An opaque type representing a non-extended public key.
+--
+-- __Properties:__
+--
+-- ===== Roundtripping
+--
+-- @forall pub. 'pubFromBytes' ('pubToBytes' pub) == 'Just' pub@
+--
+-- @since 3.12.0
+newtype Pub = Pub ByteString
+
+-- | Construct a 'Pub' from raw 'ByteString' (32 bytes).
+--
+-- @since 3.12.0
+pubFromBytes :: ByteString -> Maybe Pub
+pubFromBytes bytes
+    | BS.length bytes /= 32 = Nothing
+    | otherwise = Just $ Pub bytes
+
+-- | Convert an 'Pub' to a raw 'ByteString' (32 bytes).
+--
+-- @since 3.12.0
+pubToBytes :: Pub -> ByteString
+pubToBytes (Pub pub) = pub
+
+-- | Extract the public key from an 'XPub' as a 'Pub' (32 bytes).
+--
+-- @since 3.12.0
+xpubToPub :: XPub -> Pub
+xpubToPub (CC.XPub pub _cc) = Pub pub
 
 -- | Construct an 'XPrv' from raw 'ByteString' (96 bytes).
 --

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -190,6 +190,7 @@ xpubChainCode (CC.XPub _pub (CC.ChainCode cc)) = cc
 --
 -- @since 3.12.0
 newtype Pub = Pub ByteString
+    deriving (Show, Eq)
 
 -- | Construct a 'Pub' from raw 'ByteString' (32 bytes).
 --

--- a/core/lib/Cardano/Address/Script.hs
+++ b/core/lib/Cardano/Address/Script.hs
@@ -286,22 +286,39 @@ keyHashFromText txt = do
         >>= maybeToRight ErrKeyHashFromTextWrongPayload . keyHashFromBytes
  where
     convertBytes hrp bytes
-        | hrp == CIP5.addr_shared_vkh  = Just (Payment, bytes)
-        | hrp == CIP5.stake_shared_vkh = Just (Delegation, bytes)
-        | hrp == CIP5.addr_vkh  = Just (Payment, bytes)
-        | hrp == CIP5.stake_vkh = Just (Delegation, bytes)
-        | hrp == CIP5.policy_vkh       = Just (Policy, bytes)
-        | hrp == CIP5.addr_shared_vk   = Just (Payment, hashCredential bytes)
-        | hrp == CIP5.addr_vk   = Just (Payment, hashCredential bytes)
-        | hrp == CIP5.addr_shared_xvk  = Just (Payment, hashCredential $ BS.take 32 bytes)
-        | hrp == CIP5.addr_xvk  = Just (Payment, hashCredential $ BS.take 32 bytes)
-        | hrp == CIP5.stake_shared_vk  = Just (Delegation, hashCredential bytes)
-        | hrp == CIP5.stake_vk  = Just (Delegation, hashCredential bytes)
-        | hrp == CIP5.stake_shared_xvk = Just (Delegation, hashCredential $ BS.take 32 bytes)
-        | hrp == CIP5.stake_xvk = Just (Delegation, hashCredential $ BS.take 32 bytes)
-        | hrp == CIP5.policy_vk        = Just (Policy, hashCredential bytes)
-        | hrp == CIP5.policy_xvk       = Just (Policy, hashCredential $ BS.take 32 bytes)
+        | hrp == CIP5.addr_shared_vkh && checkBSLength bytes 28 =
+              Just (Payment, bytes)
+        | hrp == CIP5.stake_shared_vkh && checkBSLength bytes 28 =
+              Just (Delegation, bytes)
+        | hrp == CIP5.addr_vkh && checkBSLength bytes 28 =
+              Just (Payment, bytes)
+        | hrp == CIP5.stake_vkh && checkBSLength bytes 28 =
+              Just (Delegation, bytes)
+        | hrp == CIP5.policy_vkh && checkBSLength bytes 28 =
+              Just (Policy, bytes)
+        | hrp == CIP5.addr_shared_vk && checkBSLength bytes 32 =
+              Just (Payment, hashCredential bytes)
+        | hrp == CIP5.addr_vk && checkBSLength bytes 32 =
+              Just (Payment, hashCredential bytes)
+        | hrp == CIP5.addr_shared_xvk && checkBSLength bytes 64 =
+              Just (Payment, hashCredential $ BS.take 32 bytes)
+        | hrp == CIP5.addr_xvk && checkBSLength bytes 64 =
+              Just (Payment, hashCredential $ BS.take 32 bytes)
+        | hrp == CIP5.stake_shared_vk && checkBSLength bytes 32 =
+              Just (Delegation, hashCredential bytes)
+        | hrp == CIP5.stake_vk && checkBSLength bytes 32 =
+              Just (Delegation, hashCredential bytes)
+        | hrp == CIP5.stake_shared_xvk && checkBSLength bytes 64 =
+              Just (Delegation, hashCredential $ BS.take 32 bytes)
+        | hrp == CIP5.stake_xvk && checkBSLength bytes 64 =
+              Just (Delegation, hashCredential $ BS.take 32 bytes)
+        | hrp == CIP5.policy_vk && checkBSLength bytes 32 =
+              Just (Policy, hashCredential bytes)
+        | hrp == CIP5.policy_xvk && checkBSLength bytes 64 =
+              Just (Policy, hashCredential $ BS.take 32 bytes)
         | otherwise                    = Nothing
+    checkBSLength bytes expLength =
+              BS.length bytes == expLength
 
 -- Validation level. Required level does basic check that will make sure the script
 -- is accepted in ledger. Recommended level collects a number of checks that will

--- a/core/lib/Cardano/Address/Script.hs
+++ b/core/lib/Cardano/Address/Script.hs
@@ -316,9 +316,9 @@ keyHashFromText txt = do
               Just (Policy, hashCredential bytes)
         | hrp == CIP5.policy_xvk && checkBSLength bytes 64 =
               Just (Policy, hashCredential $ BS.take 32 bytes)
-        | otherwise                    = Nothing
+        | otherwise = Nothing
     checkBSLength bytes expLength =
-              BS.length bytes == expLength
+        BS.length bytes == expLength
 
 -- Validation level. Required level does basic check that will make sure the script
 -- is accepted in ledger. Recommended level collects a number of checks that will

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -116,7 +116,7 @@ import Cardano.Address.Derivation
 import Cardano.Address.Internal
     ( WithErrorMessage (..), orElse )
 import Cardano.Address.Script
-    ( KeyHash (..), KeyRole (..), ScriptHash (..) )
+    ( KeyHash (..), KeyRole (..), Script, ScriptHash (..), toScriptHash )
 import Cardano.Mnemonic
     ( SomeMnemonic, someMnemonicToBytes )
 import Codec.Binary.Encoding
@@ -736,6 +736,7 @@ data instance Credential 'PaymentK where
     PaymentFromKey :: Shelley 'PaymentK Pub -> Credential 'PaymentK
     PaymentFromExtendedKey :: Shelley 'PaymentK XPub -> Credential 'PaymentK
     PaymentFromKeyHash :: KeyHash -> Credential 'PaymentK
+    PaymentFromScript :: Script KeyHash -> Credential 'PaymentK
     PaymentFromScriptHash :: ScriptHash -> Credential 'PaymentK
     deriving Show
 
@@ -776,6 +777,12 @@ paymentAddress discrimination = \case
     PaymentFromKeyHash (KeyHash keyrole _) ->
         error $ "Payment credential should be built from key hash having payment"
         <> " role. Key hash with " <> show keyrole <> " was used."
+    PaymentFromScript script ->
+        let (ScriptHash bytes) = toScriptHash script
+        in constructPayload
+           (EnterpriseAddress CredentialFromScript)
+           discrimination
+           bytes
     PaymentFromScriptHash (ScriptHash bytes) ->
         constructPayload
             (EnterpriseAddress CredentialFromScript)

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -407,7 +407,7 @@ deriveDelegationPrivateKey accXPrv =
 --
 -- > let (Right tag) = mkNetworkDiscriminant 1
 -- > let paymentCredential = PaymentFromExtendedKey $ (toXPub <$> addrK)
--- > let delegationCredential = DelegationFromKey $ (toXPub <$> stakeK)
+-- > let delegationCredential = DelegationFromExtendedKey $ (toXPub <$> stakeK)
 -- > bech32 $ delegationAddress tag paymentCredential delegationCredential
 -- > "addr1qxpfffuj3zkp5g7ct6h4va89caxx9ayq2gvkyfvww48sdn7nudck0fzve4346yytz3wpwv9yhlxt7jwuc7ytwx2vfkyqmkc5xa"
 --
@@ -740,7 +740,7 @@ data instance Credential 'PaymentK where
     deriving Show
 
 data instance Credential 'DelegationK where
-    DelegationFromKey :: Shelley 'DelegationK XPub -> Credential 'DelegationK
+    DelegationFromExtendedKey :: Shelley 'DelegationK XPub -> Credential 'DelegationK
     DelegationFromKeyHash :: KeyHash -> Credential 'DelegationK
     DelegationFromScriptHash :: ScriptHash -> Credential 'DelegationK
     DelegationFromPointer :: ChainPointer -> Credential 'DelegationK
@@ -820,7 +820,7 @@ stakeAddress
     -> Credential 'DelegationK
     -> Either ErrInvalidStakeAddress Address
 stakeAddress discrimination = \case
-    DelegationFromKey keyPub ->
+    DelegationFromExtendedKey keyPub ->
         Right $ constructPayload
             (RewardAccount CredentialFromKey)
             discrimination
@@ -878,7 +878,7 @@ extendAddress addr infoStakeReference = do
     case infoStakeReference of
         -- base address: keyhash28,keyhash28    : 00000000 -> 0
         -- base address: scripthash32,keyhash28 : 00010000 -> 16
-        DelegationFromKey delegationKey -> do
+        DelegationFromExtendedKey delegationKey -> do
             pure $ unsafeMkAddress $ BL.toStrict $ runPut $ do
                 -- 0b01100000 .&. 0b00011111 = 0
                 -- 0b01110000 .&. 0b00011111 = 16

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -440,7 +440,7 @@ goldenTestBaseAddressPayFromXPub GoldenTestBaseAddress{..} =
         let (Right tag) = mkNetworkDiscriminant netTag
         let baseAddr =
                 delegationAddress tag (PaymentFromExtendedKey addrXPub)
-                (DelegationFromKey stakeXPub)
+                (DelegationFromExtendedKey stakeXPub)
         let (Right bytes) = b16decode expectedAddr
         baseAddr `shouldBe` unsafeMkAddress bytes
 
@@ -456,7 +456,7 @@ goldenTestBaseAddressPayFromPub GoldenTestBaseAddress{..} =
         let (Right tag) = mkNetworkDiscriminant netTag
         let baseAddr =
                 delegationAddress tag (PaymentFromKey addrPub)
-                (DelegationFromKey stakeXPub)
+                (DelegationFromExtendedKey stakeXPub)
         let (Right bytes) = b16decode expectedAddr
         baseAddr `shouldBe` unsafeMkAddress bytes
 
@@ -472,12 +472,12 @@ goldenTestBaseAddressPayFromKeyHash GoldenTestBaseAddress{..} =
         let (Right tag) = mkNetworkDiscriminant netTag
         let baseAddrPayFromKey =
                 delegationAddress tag (PaymentFromExtendedKey addrXPub)
-                (DelegationFromKey stakeXPub)
+                (DelegationFromExtendedKey stakeXPub)
         let keyHashDigest = hashCredential $ BS.take 32 paymentBs
         let keyHash = KeyHash Payment keyHashDigest
         let baseAddrPayFromKeyHash =
                 delegationAddress tag (PaymentFromKeyHash keyHash)
-                (DelegationFromKey stakeXPub)
+                (DelegationFromExtendedKey stakeXPub)
         baseAddrPayFromKey `shouldBe` baseAddrPayFromKeyHash
 
 goldenTestBaseAddressStakeFromKeyHash :: GoldenTestBaseAddress -> SpecWith ()
@@ -492,7 +492,7 @@ goldenTestBaseAddressStakeFromKeyHash GoldenTestBaseAddress{..} =
         let (Right tag) = mkNetworkDiscriminant netTag
         let baseAddrStakeFromKey =
                 delegationAddress tag (PaymentFromExtendedKey addrXPub)
-                (DelegationFromKey stakeXPub)
+                (DelegationFromExtendedKey stakeXPub)
         let keyHashDigest = hashCredential $ BS.take 32 stakeBs
         let keyHash = KeyHash Delegation keyHashDigest
         let baseAddrStakeFromKeyHash =
@@ -512,7 +512,7 @@ goldenTestBaseAddressBothFromKeyHash GoldenTestBaseAddress{..} =
         let (Right tag) = mkNetworkDiscriminant netTag
         let baseAddrBothFromKey =
                 delegationAddress tag (PaymentFromExtendedKey addrXPub)
-                (DelegationFromKey stakeXPub)
+                (DelegationFromExtendedKey stakeXPub)
         let paymentKeyHashDigest = hashCredential $ BS.take 32 paymentBs
         let paymentKeyHash = KeyHash Payment paymentKeyHashDigest
         let stakeKeyHashDigest = hashCredential $ BS.take 32 stakeBs
@@ -660,13 +660,13 @@ testVectors mnemonic = describe (show $ T.unpack <$> mnemonic) $ do
     let pointerAddr0Slot2 = getPointerAddr addrK0prv slot2 <$> networkTags
 
     let stakeKPub0 = toXPub <$> deriveDelegationPrivateKey acctK0
-    let delegationAddr0Stake0 = getDelegationAddr addrK0prv (DelegationFromKey stakeKPub0) <$> networkTags
-    let delegationAddr1Stake0 = getDelegationAddr addrK1prv (DelegationFromKey stakeKPub0) <$> networkTags
-    let delegationAddr1442Stake0 = getDelegationAddr addrK1442prv (DelegationFromKey stakeKPub0) <$> networkTags
+    let delegationAddr0Stake0 = getDelegationAddr addrK0prv (DelegationFromExtendedKey stakeKPub0) <$> networkTags
+    let delegationAddr1Stake0 = getDelegationAddr addrK1prv (DelegationFromExtendedKey stakeKPub0) <$> networkTags
+    let delegationAddr1442Stake0 = getDelegationAddr addrK1442prv (DelegationFromExtendedKey stakeKPub0) <$> networkTags
     let stakeKPub1 = toXPub <$> deriveDelegationPrivateKey acctK1
-    let delegationAddr0Stake1 = getDelegationAddr addrK0prv (DelegationFromKey stakeKPub1) <$> networkTags
-    let delegationAddr1Stake1 = getDelegationAddr addrK1prv (DelegationFromKey stakeKPub1) <$> networkTags
-    let delegationAddr1442Stake1 = getDelegationAddr addrK1442prv (DelegationFromKey stakeKPub1) <$> networkTags
+    let delegationAddr0Stake1 = getDelegationAddr addrK0prv (DelegationFromExtendedKey stakeKPub1) <$> networkTags
+    let delegationAddr1Stake1 = getDelegationAddr addrK1prv (DelegationFromExtendedKey stakeKPub1) <$> networkTags
+    let delegationAddr1442Stake1 = getDelegationAddr addrK1442prv (DelegationFromExtendedKey stakeKPub1) <$> networkTags
     let vec = TestVector {..}
     let inspectVec = InspectVector {..}
     it "should generate correct addresses" $ do
@@ -732,7 +732,7 @@ prop_roundtripTextEncodingDelegation encode' decode addXPub delegXPub discrimina
             ])
         & label (show $ addressDiscrimination @Shelley discrimination)
   where
-    address = delegationAddress discrimination (PaymentFromExtendedKey addXPub) (DelegationFromKey delegXPub)
+    address = delegationAddress discrimination (PaymentFromExtendedKey addXPub) (DelegationFromExtendedKey delegXPub)
     result  = decode (encode' address)
 
 prop_roundtripTextEncodingPointer

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -243,6 +243,20 @@ spec = do
             ,  expectedAddr =
                     "018a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
             }
+        goldenTestBaseAddressStakeFromPub GoldenTestBaseAddress
+            {  verKeyPayment = "1a2a3a4a5a6a7a8a"
+            ,  verKeyStake = "1c2c3c4c5c6c7c8c"
+            ,  netTag = 0
+            ,  expectedAddr =
+                    "008a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
+            }
+        goldenTestBaseAddressStakeFromPub GoldenTestBaseAddress
+            {  verKeyPayment = "1a2a3a4a5a6a7a8a"
+            ,  verKeyStake = "1c2c3c4c5c6c7c8c"
+            ,  netTag = 1
+            ,  expectedAddr =
+                    "018a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
+            }
         goldenTestBaseAddressBothFromKeyHash GoldenTestBaseAddress
             {  verKeyPayment = "1a2a3a4a5a6a7a8a"
             ,  verKeyStake = "1c2c3c4c5c6c7c8c"
@@ -251,6 +265,20 @@ spec = do
                     "008a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
             }
         goldenTestBaseAddressBothFromKeyHash GoldenTestBaseAddress
+            {  verKeyPayment = "1a2a3a4a5a6a7a8a"
+            ,  verKeyStake = "1c2c3c4c5c6c7c8c"
+            ,  netTag = 1
+            ,  expectedAddr =
+                    "018a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
+            }
+        goldenTestBaseAddressBothFromPub GoldenTestBaseAddress
+            {  verKeyPayment = "1a2a3a4a5a6a7a8a"
+            ,  verKeyStake = "1c2c3c4c5c6c7c8c"
+            ,  netTag = 0
+            ,  expectedAddr =
+                    "008a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4"
+            }
+        goldenTestBaseAddressBothFromPub GoldenTestBaseAddress
             {  verKeyPayment = "1a2a3a4a5a6a7a8a"
             ,  verKeyStake = "1c2c3c4c5c6c7c8c"
             ,  netTag = 1
@@ -500,6 +528,27 @@ goldenTestBaseAddressStakeFromKeyHash GoldenTestBaseAddress{..} =
                 (DelegationFromKeyHash keyHash)
         baseAddrStakeFromKey `shouldBe` baseAddrStakeFromKeyHash
 
+goldenTestBaseAddressStakeFromPub :: GoldenTestBaseAddress -> SpecWith ()
+goldenTestBaseAddressStakeFromPub GoldenTestBaseAddress{..} =
+    it ("base address for networkId " <> show netTag) $ do
+        let paymentBs = b16encode $ T.append verKeyPayment verKeyPayment
+        let (Just xPub1) = xpubFromBytes paymentBs
+        let addrXPub = liftXPub xPub1 :: Shelley 'PaymentK XPub
+        let stakeBs = b16encode $ T.append verKeyStake verKeyStake
+        let (Just xPub2) = xpubFromBytes stakeBs
+        let stakeXPub = liftXPub xPub2 :: Shelley 'DelegationK XPub
+        let (Right tag) = mkNetworkDiscriminant netTag
+        let baseAddrStakeFromExtendedKey =
+                delegationAddress tag (PaymentFromExtendedKey addrXPub)
+                (DelegationFromExtendedKey stakeXPub)
+        let stakeBs1 = b16encode verKeyStake
+        let (Just pub2) = pubFromBytes stakeBs1
+        let stakePub = liftPub pub2 :: Shelley 'DelegationK Pub
+        let baseAddrStakeFromKey =
+                delegationAddress tag (PaymentFromExtendedKey addrXPub)
+                (DelegationFromKey stakePub)
+        baseAddrStakeFromExtendedKey `shouldBe` baseAddrStakeFromKey
+
 goldenTestBaseAddressBothFromKeyHash :: GoldenTestBaseAddress -> SpecWith ()
 goldenTestBaseAddressBothFromKeyHash GoldenTestBaseAddress{..} =
     it ("base address for networkId " <> show netTag) $ do
@@ -521,6 +570,30 @@ goldenTestBaseAddressBothFromKeyHash GoldenTestBaseAddress{..} =
                 delegationAddress tag (PaymentFromKeyHash paymentKeyHash)
                 (DelegationFromKeyHash stakeKeyHash)
         baseAddrBothFromKey `shouldBe` baseAddrBothFromKeyHash
+
+goldenTestBaseAddressBothFromPub :: GoldenTestBaseAddress -> SpecWith ()
+goldenTestBaseAddressBothFromPub GoldenTestBaseAddress{..} =
+    it ("base address for networkId " <> show netTag) $ do
+        let paymentBs = b16encode $ T.append verKeyPayment verKeyPayment
+        let (Just xPub1) = xpubFromBytes paymentBs
+        let addrXPub = liftXPub xPub1 :: Shelley 'PaymentK XPub
+        let stakeBs = b16encode $ T.append verKeyStake verKeyStake
+        let (Just xPub2) = xpubFromBytes stakeBs
+        let stakeXPub = liftXPub xPub2 :: Shelley 'DelegationK XPub
+        let (Right tag) = mkNetworkDiscriminant netTag
+        let baseAddrBothFromKey =
+                delegationAddress tag (PaymentFromExtendedKey addrXPub)
+                (DelegationFromExtendedKey stakeXPub)
+        let paymentBs1 = b16encode verKeyPayment
+        let (Just pub1) = pubFromBytes paymentBs1
+        let addrPub = liftPub pub1 :: Shelley 'PaymentK Pub
+        let stakeBs1 = b16encode verKeyStake
+        let (Just pub2) = pubFromBytes stakeBs1
+        let stakePub = liftPub pub2 :: Shelley 'DelegationK Pub
+        let baseAddrBothFromPub =
+                delegationAddress tag (PaymentFromKey addrPub)
+                (DelegationFromKey stakePub)
+        baseAddrBothFromKey `shouldBe` baseAddrBothFromPub
 
 
 data TestVector = TestVector


### PR DESCRIPTION
https://input-output.atlassian.net/browse/ADP-2114

The PR extends address construction for payment/delegation/reward addresses by adding credential via:
- script
- non-extended key
This is on top of extended key, key hash, script hash (and from pointer for delegation credential).

The functionalities are also supported in CLI. The tests are added, docs revisited and extended