### PR TITLE
Add support for preview and preprod

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+## [3.13.0] - N/A
+
+### Added
+
+- Support for new environments `preview` and `preprod`.
+
 ## [3.12.0] - 2022-08-17
 
 ### Added

--- a/command-line/lib/Command/Address/Bootstrap.hs
+++ b/command-line/lib/Command/Address/Bootstrap.hs
@@ -69,7 +69,7 @@ mod liftCmd = command "bootstrap" $
             , indent 4 $ bold $ string $ "| "<>progName<>" key child 14H/42H | tee addr.prv \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" key public --with-chain-code \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" address bootstrap --root $(cat root.prv | "<>progName<>" key public --with-chain-code) \\"
-            , indent 8 $ bold $ string "--network-tag testnet 14H/42H"
+            , indent 8 $ bold $ string "--network-tag preview 14H/42H"
             , indent 2 $ string "DdzFFzCqrht2KG1vWt5WGhVC9Ezyu32RgB5M2DocdZ6BQU6zj69LSqksDmdM..."
             ])
   where

--- a/command-line/lib/Command/Address/Bootstrap.hs
+++ b/command-line/lib/Command/Address/Bootstrap.hs
@@ -70,7 +70,7 @@ mod liftCmd = command "bootstrap" $
             , indent 4 $ bold $ string $ "| "<>progName<>" key public --with-chain-code \\"
             , indent 4 $ bold $ string $ "| "<>progName<>" address bootstrap --root $(cat root.prv | "<>progName<>" key public --with-chain-code) \\"
             , indent 8 $ bold $ string "--network-tag preview 14H/42H"
-            , indent 2 $ string "DdzFFzCqrht2KG1vWt5WGhVC9Ezyu32RgB5M2DocdZ6BQU6zj69LSqksDmdM..."
+            , indent 2 $ string "KjgoiXJS2coBYYTM69pafiau6bbGqKrzbFiRzahpWsPvit48YNiHocPpB7VJ..."
             ])
   where
     parser = Cmd

--- a/command-line/lib/Options/Applicative/Discrimination.hs
+++ b/command-line/lib/Options/Applicative/Discrimination.hs
@@ -91,6 +91,7 @@ networkTagOpt style = option (eitherReader reader) $ mempty
         Byron ->
             [ unNetworkTag (snd Byron.byronMainnet)
             , unNetworkTag (snd Byron.byronStaging)
+            , unNetworkTag (snd Byron.byronTestnet)
             , unNetworkTag (snd Byron.byronPreprod)
             , unNetworkTag (snd Byron.byronPreview)
             ]
@@ -115,6 +116,7 @@ networkTagOpt style = option (eitherReader reader) $ mempty
     readKeywordMaybe str = \case
         Byron | str == "mainnet" -> pure (snd Byron.byronMainnet)
         Byron | str == "staging" -> pure (snd Byron.byronStaging)
+        Byron | str == "testnet" -> pure (snd Byron.byronTestnet)
         Byron | str == "preview" -> pure (snd Byron.byronPreview)
         Byron | str == "preprod" -> pure (snd Byron.byronPreprod)
         Icarus -> readKeywordMaybe str Byron
@@ -125,7 +127,7 @@ networkTagOpt style = option (eitherReader reader) $ mempty
         _ -> Nothing
 
     allowedKeywords = \case
-        Byron -> ["mainnet", "staging", "preview", "preprod"]
+        Byron -> ["mainnet", "staging", "testnet", "preview", "preprod"]
         Icarus -> allowedKeywords Byron
         Shelley -> ["mainnet", "testnet (good for preview or preprod)"]
         Shared -> ["mainnet", "testnet (good for preview or preprod)"]

--- a/command-line/lib/Options/Applicative/Discrimination.hs
+++ b/command-line/lib/Options/Applicative/Discrimination.hs
@@ -91,7 +91,8 @@ networkTagOpt style = option (eitherReader reader) $ mempty
         Byron ->
             [ unNetworkTag (snd Byron.byronMainnet)
             , unNetworkTag (snd Byron.byronStaging)
-            , unNetworkTag (snd Byron.byronTestnet)
+            , unNetworkTag (snd Byron.byronPreprod)
+            , unNetworkTag (snd Byron.byronPreview)
             ]
         Icarus ->
             tagsFor Byron
@@ -114,7 +115,8 @@ networkTagOpt style = option (eitherReader reader) $ mempty
     readKeywordMaybe str = \case
         Byron | str == "mainnet" -> pure (snd Byron.byronMainnet)
         Byron | str == "staging" -> pure (snd Byron.byronStaging)
-        Byron | str == "testnet" -> pure (snd Byron.byronTestnet)
+        Byron | str == "preview" -> pure (snd Byron.byronPreview)
+        Byron | str == "preprod" -> pure (snd Byron.byronPreprod)
         Icarus -> readKeywordMaybe str Byron
         Shelley | str == "mainnet" -> pure Shelley.shelleyMainnet
         Shelley | str == "testnet" -> pure Shelley.shelleyTestnet
@@ -123,7 +125,7 @@ networkTagOpt style = option (eitherReader reader) $ mempty
         _ -> Nothing
 
     allowedKeywords = \case
-        Byron -> ["mainnet", "staging", "testnet"]
+        Byron -> ["mainnet", "staging", "preview", "preprod"]
         Icarus -> allowedKeywords Byron
-        Shelley -> ["mainnet", "testnet"]
-        Shared -> ["mainnet", "testnet"]
+        Shelley -> ["mainnet", "testnet (good for preview or preprod)"]
+        Shared -> ["mainnet", "testnet (good for preview or preprod)"]

--- a/command-line/lib/Options/Applicative/Discrimination.hs
+++ b/command-line/lib/Options/Applicative/Discrimination.hs
@@ -122,12 +122,16 @@ networkTagOpt style = option (eitherReader reader) $ mempty
         Icarus -> readKeywordMaybe str Byron
         Shelley | str == "mainnet" -> pure Shelley.shelleyMainnet
         Shelley | str == "testnet" -> pure Shelley.shelleyTestnet
+        Shelley | str == "preview" -> pure Shelley.shelleyTestnet
+        Shelley | str == "preprod" -> pure Shelley.shelleyTestnet
         Shared | str == "mainnet" -> pure Shelley.shelleyMainnet
         Shared | str == "testnet" -> pure Shelley.shelleyTestnet
+        Shared | str == "preview" -> pure Shelley.shelleyTestnet
+        Shared | str == "preprod" -> pure Shelley.shelleyTestnet
         _ -> Nothing
 
     allowedKeywords = \case
         Byron -> ["mainnet", "staging", "testnet", "preview", "preprod"]
         Icarus -> allowedKeywords Byron
-        Shelley -> ["mainnet", "testnet (good for preview or preprod)"]
-        Shared -> ["mainnet", "testnet (good for preview or preprod)"]
+        Shelley -> ["mainnet", "testnet", "preview", "preprod"]
+        Shared -> allowedKeywords Shelley

--- a/core/lib/Cardano/Address/Style/Byron.hs
+++ b/core/lib/Cardano/Address/Style/Byron.hs
@@ -54,7 +54,8 @@ module Cardano.Address.Style.Byron
       -- * Network Discrimination
     , byronMainnet
     , byronStaging
-    , byronTestnet
+    , byronPreprod
+    , byronPreview
 
       -- * Unsafe
     , liftXPrv
@@ -495,11 +496,17 @@ byronMainnet = (RequiresNoTag, NetworkTag 764824073)
 byronStaging :: NetworkDiscriminant Byron
 byronStaging = (RequiresNetworkTag, NetworkTag 633343913)
 
--- | 'NetworkDiscriminant' for Cardano TestNet & Byron
+-- | 'NetworkDiscriminant' for Cardano Preview & Byron
 --
--- @since 2.0.0
-byronTestnet :: NetworkDiscriminant Byron
-byronTestnet = (RequiresNetworkTag, NetworkTag 1097911063)
+-- @since 3.13.0
+byronPreview :: NetworkDiscriminant Byron
+byronPreview = (RequiresNetworkTag, NetworkTag 2)
+
+-- | 'NetworkDiscriminant' for Cardano Preprod & Byron
+--
+-- @since 3.13.0
+byronPreprod :: NetworkDiscriminant Byron
+byronPreprod = (RequiresNetworkTag, NetworkTag 1)
 
 --
 -- Unsafe

--- a/core/lib/Cardano/Address/Style/Byron.hs
+++ b/core/lib/Cardano/Address/Style/Byron.hs
@@ -54,6 +54,7 @@ module Cardano.Address.Style.Byron
       -- * Network Discrimination
     , byronMainnet
     , byronStaging
+    , byronTestnet
     , byronPreprod
     , byronPreview
 
@@ -495,6 +496,12 @@ byronMainnet = (RequiresNoTag, NetworkTag 764824073)
 -- @since 2.0.0
 byronStaging :: NetworkDiscriminant Byron
 byronStaging = (RequiresNetworkTag, NetworkTag 633343913)
+
+-- | 'NetworkDiscriminant' for Cardano Testnet & Byron
+--
+-- @since 2.0.0
+byronTestnet :: NetworkDiscriminant Byron
+byronTestnet = (RequiresNetworkTag, NetworkTag 1097911063)
 
 -- | 'NetworkDiscriminant' for Cardano Preview & Byron
 --

--- a/core/lib/Cardano/Address/Style/Icarus.hs
+++ b/core/lib/Cardano/Address/Style/Icarus.hs
@@ -50,7 +50,8 @@ module Cardano.Address.Style.Icarus
       -- * Network Discrimination
     , icarusMainnet
     , icarusStaging
-    , icarusTestnet
+    , icarusPreview
+    , icarusPreprod
 
       -- * Unsafe
     , liftXPrv
@@ -88,7 +89,7 @@ import Cardano.Address.Derivation
 import Cardano.Address.Internal
     ( DeserialiseFailure, WithErrorMessage (..) )
 import Cardano.Address.Style.Byron
-    ( byronMainnet, byronStaging, byronTestnet )
+    ( byronMainnet, byronStaging, byronPreview, byronPreprod )
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToBytes, mnemonicToEntropy, mnemonicToText )
 import Codec.Binary.Encoding
@@ -474,11 +475,17 @@ icarusMainnet = byronMainnet
 icarusStaging :: NetworkDiscriminant Icarus
 icarusStaging = byronStaging
 
--- | 'NetworkDiscriminant' for Cardano TestNet & 'Icarus'
+-- | 'NetworkDiscriminant' for Cardano Preprod & 'Icarus'
 --
--- @since 2.0.0
-icarusTestnet :: NetworkDiscriminant Icarus
-icarusTestnet = byronTestnet
+-- @since 3.13.0
+icarusPreprod :: NetworkDiscriminant Icarus
+icarusPreprod = byronPreprod
+
+-- | 'NetworkDiscriminant' for Cardano Preprod & 'Icarus'
+--
+-- @since 3.13.0
+icarusPreview :: NetworkDiscriminant Icarus
+icarusPreview = byronPreview
 
 --
 -- Unsafe

--- a/core/lib/Cardano/Address/Style/Icarus.hs
+++ b/core/lib/Cardano/Address/Style/Icarus.hs
@@ -50,6 +50,7 @@ module Cardano.Address.Style.Icarus
       -- * Network Discrimination
     , icarusMainnet
     , icarusStaging
+    , icarusTestnet
     , icarusPreview
     , icarusPreprod
 
@@ -89,7 +90,7 @@ import Cardano.Address.Derivation
 import Cardano.Address.Internal
     ( DeserialiseFailure, WithErrorMessage (..) )
 import Cardano.Address.Style.Byron
-    ( byronMainnet, byronPreprod, byronPreview, byronStaging )
+    ( byronMainnet, byronPreprod, byronPreview, byronStaging, byronTestnet )
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToBytes, mnemonicToEntropy, mnemonicToText )
 import Codec.Binary.Encoding
@@ -475,13 +476,19 @@ icarusMainnet = byronMainnet
 icarusStaging :: NetworkDiscriminant Icarus
 icarusStaging = byronStaging
 
+-- | 'NetworkDiscriminant' for Cardano Testnet & 'Icarus'
+--
+-- @since 2.0.0
+icarusTestnet :: NetworkDiscriminant Icarus
+icarusTestnet = byronTestnet
+
 -- | 'NetworkDiscriminant' for Cardano Preprod & 'Icarus'
 --
 -- @since 3.13.0
 icarusPreprod :: NetworkDiscriminant Icarus
 icarusPreprod = byronPreprod
 
--- | 'NetworkDiscriminant' for Cardano Preprod & 'Icarus'
+-- | 'NetworkDiscriminant' for Cardano Preview & 'Icarus'
 --
 -- @since 3.13.0
 icarusPreview :: NetworkDiscriminant Icarus

--- a/core/lib/Cardano/Address/Style/Icarus.hs
+++ b/core/lib/Cardano/Address/Style/Icarus.hs
@@ -89,7 +89,7 @@ import Cardano.Address.Derivation
 import Cardano.Address.Internal
     ( DeserialiseFailure, WithErrorMessage (..) )
 import Cardano.Address.Style.Byron
-    ( byronMainnet, byronStaging, byronPreview, byronPreprod )
+    ( byronMainnet, byronPreprod, byronPreview, byronStaging )
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToBytes, mnemonicToEntropy, mnemonicToText )
 import Codec.Binary.Encoding

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -35,9 +35,9 @@ import Cardano.Address.Derivation
     , xprvToBytes
     )
 import Cardano.Address.Style.Byron
-    ( Byron, byronMainnet, byronStaging, byronPreview, byronPreprod)
+    ( Byron, byronMainnet, byronPreprod, byronPreview, byronStaging )
 import Cardano.Address.Style.Icarus
-    ( Icarus, icarusMainnet, icarusStaging, icarusPreview, icarusPreprod)
+    ( Icarus, icarusMainnet, icarusPreprod, icarusPreview, icarusStaging )
 import Cardano.Address.Style.Shelley
     ( Shelley )
 import Cardano.Mnemonic

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -35,9 +35,9 @@ import Cardano.Address.Derivation
     , xprvToBytes
     )
 import Cardano.Address.Style.Byron
-    ( Byron, byronMainnet, byronStaging, byronTestnet )
+    ( Byron, byronMainnet, byronStaging, byronPreview, byronPreprod)
 import Cardano.Address.Style.Icarus
-    ( Icarus, icarusMainnet, icarusStaging, icarusTestnet )
+    ( Icarus, icarusMainnet, icarusStaging, icarusPreview, icarusPreprod)
 import Cardano.Address.Style.Shelley
     ( Shelley )
 import Cardano.Mnemonic
@@ -184,10 +184,12 @@ instance {-# OVERLAPS #-} Arbitrary (AddressDiscrimination, NetworkTag) where
         , (RequiresNetworkTag,) <$> arbitrary
         , pure byronMainnet
         , pure byronStaging
-        , pure byronTestnet
+        , pure byronPreview
+        , pure byronPreprod
         , pure icarusMainnet
         , pure icarusStaging
-        , pure icarusTestnet
+        , pure icarusPreview
+        , pure icarusPreprod
         ]
 
 instance Arbitrary NetworkTag where

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -35,9 +35,21 @@ import Cardano.Address.Derivation
     , xprvToBytes
     )
 import Cardano.Address.Style.Byron
-    ( Byron, byronMainnet, byronPreprod, byronPreview, byronStaging )
+    ( Byron
+    , byronMainnet
+    , byronPreprod
+    , byronPreview
+    , byronStaging
+    , byronTestnet
+    )
 import Cardano.Address.Style.Icarus
-    ( Icarus, icarusMainnet, icarusPreprod, icarusPreview, icarusStaging )
+    ( Icarus
+    , icarusMainnet
+    , icarusPreprod
+    , icarusPreview
+    , icarusStaging
+    , icarusTestnet
+    )
 import Cardano.Address.Style.Shelley
     ( Shelley )
 import Cardano.Mnemonic
@@ -184,10 +196,12 @@ instance {-# OVERLAPS #-} Arbitrary (AddressDiscrimination, NetworkTag) where
         , (RequiresNetworkTag,) <$> arbitrary
         , pure byronMainnet
         , pure byronStaging
+        , pure byronTestnet
         , pure byronPreview
         , pure byronPreprod
         , pure icarusMainnet
         , pure icarusStaging
+        , pure icarusTestnet
         , pure icarusPreview
         , pure icarusPreprod
         ]


### PR DESCRIPTION
- [x] Add support for preview and preprod (d9130103069cb47157b409808fe3f22bae005add) 
- [x] Update tests and examples (2cf0d00af19e02a00d78fe50f093beaa2f4e10f5) 
- [x] Update changelog (332627ffb41d0372dfb6ccbec6d4e1a5d07ca433)

## Comment
After this we have:
```
$ cardano-address address bootstrap
Those addresses, now deprecated, were used during the Byron era.

Usage: cardano-address address bootstrap [--root XPUB] --network-tag NETWORK-TAG
                                         [DERIVATION-PATH]
  Create a bootstrap address

Available options:
  -h,--help                Show this help text
  --root XPUB              A root public key. Needed for Byron addresses only.
  --network-tag NETWORK-TAG
                           A tag which identifies a Cardano network.
                           
                           ┌ Byron / Icarus ──────────
                           │ 
                           │ mainnet
                           │ staging
                           │ testnet
                           │ preview
                           │ preprod
```

```
$ cardano-address address payment
Payment addresses carry no delegation rights whatsoever.

Usage: cardano-address address payment --network-tag NETWORK-TAG [SCRIPT]
  Create a payment address

Available options:
  -h,--help                Show this help text
  --network-tag NETWORK-TAG
                           A tag which identifies a Cardano network.
                           
                           ┌ Shelley ─────────────────
                           │ 
                           │ mainnet
                           │ testnet
                           │ preview
                           │ preprod
```

## Issue

https://input-output.atlassian.net/browse/ADP-2188