### PR TITLE
Use environment files in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,8 +99,8 @@ jobs:
     - name: 🏷️ Variables
       id: variables
       run: |
-        echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
-        echo ::set-output name=pkg_name::$(cat core/*.cabal | grep "name:" | sed "s/name:\s*\(.*\)/\1/")
+        echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+        echo "pkg_name=$(cat core/*.cabal | grep "name:" | sed "s/name:\s*\(.*\)/\1/")" >> $GITHUB_OUTPUT
 
     - name: 🐧 Download Artifact (linux)
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
       id: variables
       shell: bash
       run: |
-        echo ::set-output name=stack_local_bin::$(stack path --local-bin)
+        echo "stack_local_bin=$(stack path --local-bin)" >> $GITHUB_OUTPUT
 
     - name: 📎 Upload Artifact
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/