### PR TITLE
haskell.nix tools include haskell-language-server

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -51,6 +51,7 @@ haskell-nix: haskell-nix.cabalProject' (
       crossPlatforms = p: [ p.ghcjs ];
       tools = {
         hpack.version = "latest";
+        haskell-language-server.version = "latest";
       };
       nativeBuildInputs = with pkgs; [ nodejs nixWrapped cabalWrapped ];
       packages = ps:

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -16,6 +16,7 @@ mkShell rec {
   tools = [
     ghc
     cabal-install
+    haskell-language-server
     stack
     nix
     pkgconfig


### PR DESCRIPTION
Makes `haskell-language-tool` available in the nix shell.