### PR TITLE
Add Unknown key role and adjust code needed

### DIFF
--- a/core/test/Cardano/Address/ScriptSpec.hs
+++ b/core/test/Cardano/Address/ScriptSpec.hs
@@ -773,7 +773,8 @@ instance Arbitrary KeyHash where
     -- on these.
     arbitrary = do
         payload' <- BS.pack <$> vectorOf 28 arbitrary
-        flip KeyHash payload' <$> oneof [pure Payment, pure Delegation]
+        flip KeyHash payload' <$>
+            oneof [pure Payment, pure Delegation, pure Policy, pure Unknown]
 
 instance Arbitrary Cosigner where
     arbitrary = Cosigner <$> arbitrary


### PR DESCRIPTION
this is part of ADP-2379. `KeyRole` was extended and `Unknown` data constructor was added. And the needed code adjusted. The change is motivated by the fact that there are situations where for a given wallet we cannot state whether a given key hash is acting as Policy/Payment/Delegation, it is external for this wallet and unknown. The keys can be represented as bytes and only upon constructing value of type KeyHash we are assuming the role. In order to handle the situation where the key hash is unknown we introduced the Unknown role. In that case we will assume hex-encoded representation - in contrast to bech32 where we the role is known.

https://input-output.atlassian.net/browse/ADP-2312   