### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         ghc-version: '8.10.7'
         enable-stack: true
-        stack-version: 'latest'
+        stack-version: '2.7.3'
 
     - name: 💾 Cache Dependencies
       id: cache

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         extra_nix_config: |
           trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          substituters = https://hydra.iohk.io https://cache.nixos.org/
+          substituters = https://cache.iog.io https://cache.nixos.org/
     - name: 'Install dependencies'
       run: 'nix-shell --run "npm install"'
     - name: 'Build'


### PR DESCRIPTION
There is a problem in that hpack was updated and several check could not go on. 
- [x] FIX: set stack before bump of hpack to 0.35.0
- [x] Fix/Remove cicero/hydra-build/hydra-eval

One more thing is needed:
- [ ] Fix Continuous Integration (Windows)
```
network                    >                  from cbits\asyncAccept.c:6:0: error: 
network                    > C:\Users\runneradmin\AppData\Local\Programs\stack\x86_64-windows\ghc-8.10.7\lib/include/stg/Types.h:26:9: warning: #warning "Mismatch between __USE_MINGW_ANSI_STDIO definitions. If using Rts.h make sure it is the first header included." [-Wcpp]
network                    >    26 | #       warning "Mismatch between __USE_MINGW_ANSI_STDIO definitions. \
network                    >       |         ^~~~~~~
network                    > In file included from C:\Users\runneradmin\AppData\Local\Programs\stack\x86_64-windows\ghc-8.10.7\lib/include/HsFFI.h:20,
``` 