### PR TITLE
Relax bounds number of participants

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
 ## [4.0.4]
+
+### Added
+
+- Relax N in RequiredSomeOf in Script to accommodate the possible number of participants above 255. Add data constructor `BigNInRequiredSomeOf` to `ErrRecommendedValidateScrip`
+- Relax the number of `Cosigner` to accommodate the possible number of participants above 255. Add `BigCosignerNumber` constructor to `ErrValidateScriptTemplate`
 	
 ## [4.0.3] - 2026-05-22
 

--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -644,11 +644,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {

--- a/lib/Cardano/Address/Crypto/BIP39.hs
+++ b/lib/Cardano/Address/Crypto/BIP39.hs
@@ -271,8 +271,7 @@ newtype Seed = Seed ByteString
 type Passphrase = Text
 
 sentenceToSeed
-    :: ValidMnemonicSentence mw
-    => MnemonicSentence mw
+    :: MnemonicSentence mw
     -> Dictionary
     -> Passphrase
     -> Seed
@@ -280,8 +279,7 @@ sentenceToSeed mw dic =
     phraseToSeed (mnemonicSentenceToMnemonicPhrase dic mw) dic
 
 phraseToSeed
-    :: ValidMnemonicSentence mw
-    => MnemonicPhrase mw
+    :: MnemonicPhrase mw
     -> Dictionary
     -> Passphrase
     -> Seed
@@ -337,8 +335,7 @@ mnemonicPhrase l =
 
 checkMnemonicPhrase
     :: forall mw
-     . ValidMnemonicSentence mw
-    => Dictionary
+     . Dictionary
     -> MnemonicPhrase mw
     -> Bool
 checkMnemonicPhrase dic (MnemonicPhrase ln) =
@@ -346,8 +343,7 @@ checkMnemonicPhrase dic (MnemonicPhrase ln) =
 
 mnemonicPhraseToMnemonicSentence
     :: forall mw
-     . ValidMnemonicSentence mw
-    => Dictionary
+     . Dictionary
     -> MnemonicPhrase mw
     -> Either DictionaryError (MnemonicSentence mw)
 mnemonicPhraseToMnemonicSentence dic (MnemonicPhrase ln) =
@@ -355,8 +351,7 @@ mnemonicPhraseToMnemonicSentence dic (MnemonicPhrase ln) =
 
 mnemonicSentenceToMnemonicPhrase
     :: forall mw
-     . ValidMnemonicSentence mw
-    => Dictionary
+     . Dictionary
     -> MnemonicSentence mw
     -> MnemonicPhrase mw
 mnemonicSentenceToMnemonicPhrase dic (MnemonicSentence ln) =
@@ -364,8 +359,7 @@ mnemonicSentenceToMnemonicPhrase dic (MnemonicSentence ln) =
 
 mnemonicPhraseToString
     :: forall mw
-     . ValidMnemonicSentence mw
-    => Dictionary
+     . Dictionary
     -> MnemonicPhrase mw
     -> Text
 mnemonicPhraseToString dic (MnemonicPhrase ln) =
@@ -375,8 +369,7 @@ mnemonicPhraseToString dic (MnemonicPhrase ln) =
 
 mnemonicSentenceToString
     :: forall mw
-     . ValidMnemonicSentence mw
-    => Dictionary
+     . Dictionary
     -> MnemonicSentence mw
     -> Text
 mnemonicSentenceToString dic =
@@ -385,8 +378,7 @@ mnemonicSentenceToString dic =
 
 translateTo
     :: forall mw
-     . ValidMnemonicSentence mw
-    => Dictionary
+     . Dictionary
     -> Dictionary
     -> MnemonicPhrase mw
     -> Either DictionaryError (MnemonicPhrase mw)

--- a/lib/Cardano/Address/Crypto/ListN.hs
+++ b/lib/Cardano/Address/Crypto/ListN.hs
@@ -17,7 +17,7 @@ module Cardano.Address.Crypto.ListN
     , toListN_
     , map
     , mapM
-    , foldl'
+    , Cardano.Address.Crypto.ListN.foldl'
     ) where
 
 import Prelude hiding

--- a/lib/Cardano/Address/Crypto/ListN.hs
+++ b/lib/Cardano/Address/Crypto/ListN.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
+{-# OPTIONS_GHC -Wno-dodgy-imports #-}
+
 -- | Vendored minimal sized-list from @basement@ (BSD-3-Clause).
 -- Only the subset used by BIP39 encoding.
 module Cardano.Address.Crypto.ListN
@@ -19,7 +21,7 @@ module Cardano.Address.Crypto.ListN
     ) where
 
 import Prelude hiding
-    ( map, mapM )
+    ( foldl', map, mapM )
 
 import Control.DeepSeq
     ( NFData )

--- a/lib/Cardano/Address/Crypto/ListN.hs
+++ b/lib/Cardano/Address/Crypto/ListN.hs
@@ -19,7 +19,7 @@ module Cardano.Address.Crypto.ListN
     ) where
 
 import Prelude hiding
-    ( foldl', map, mapM )
+    ( map, mapM )
 
 import Control.DeepSeq
     ( NFData )

--- a/lib/Cardano/Address/Script.hs
+++ b/lib/Cardano/Address/Script.hs
@@ -536,6 +536,8 @@ validateScriptTemplate level (ScriptTemplate cosigners_ script) = do
     check DuplicateXPubs (Set.size cosignerKeys == Map.size cosigners_)
     check UnknownCosigner (cosignerSet `Set.isSubsetOf` scriptCosigners)
     check MissingCosignerXPub (scriptCosigners `Set.isSubsetOf` cosignerSet)
+    when (level == RecommendedValidation) $
+        check BigCosignerNumber (all (\(Cosigner n) -> n <= 255) scriptCosigners)
   where
     scriptCosigners = Set.fromList $ foldScript (:) [] script
     cosignerKeys = Set.fromList $ Map.elems cosigners_
@@ -591,6 +593,7 @@ data ErrValidateScriptTemplate
     | MissingCosignerXPub
     | NoCosignerInScript
     | NoCosignerXPub
+    | BigCosignerNumber
     deriving (Eq, Show)
 
 -- | Pretty-print a script validation error.
@@ -649,6 +652,8 @@ prettyErrValidateScriptTemplate = \case
         "The script template must have at least one cosigner with an extended public key."
     UnknownCosigner ->
         "The specified cosigner must be present in the script of the template."
+    BigCosignerNumber ->
+        "The script template contains a cosigner number greater than 255. Such scripts might result in transactions exceeding the possible transaction size limit (which is not recommended)."
 --
 -- Internal
 --

--- a/lib/Cardano/Address/Script.hs
+++ b/lib/Cardano/Address/Script.hs
@@ -105,8 +105,6 @@ import Data.Text
     ( Text )
 import Data.Traversable
     ( for )
-import Data.Word
-    ( Word )
 import GHC.Generics
     ( Generic )
 import Numeric.Natural

--- a/lib/Cardano/Address/Script.hs
+++ b/lib/Cardano/Address/Script.hs
@@ -106,7 +106,7 @@ import Data.Text
 import Data.Traversable
     ( for )
 import Data.Word
-    ( Word8 )
+    ( Word )
 import GHC.Generics
     ( Generic )
 import Numeric.Natural
@@ -134,7 +134,7 @@ data Script (elem :: Type)
     = RequireSignatureOf !elem
     | RequireAllOf ![Script elem]
     | RequireAnyOf ![Script elem]
-    | RequireSomeOf Word8 ![Script elem]
+    | RequireSomeOf Word ![Script elem]
     | ActiveFromSlot Natural
     | ActiveUntilSlot Natural
     deriving stock (Generic, Show, Eq)
@@ -190,7 +190,7 @@ serializeScript script =
 -- | Represents the cosigner of the script, ie., party that co-shares the script.
 --
 -- @since 3.2.0
-newtype Cosigner = Cosigner Word8
+newtype Cosigner = Cosigner Word
     deriving (Generic, Ord, Eq)
 instance Hashable Cosigner
 instance NFData Cosigner
@@ -791,11 +791,12 @@ instance ToJSON Cosigner where
 
 instance FromJSON Cosigner where
     parseJSON = withText "Cosigner" $ \txt -> case T.splitOn "cosigner#" txt of
-        ["",numTxt] ->  case T.decimal numTxt of
+        ["",numTxt] ->  case T.decimal @Integer numTxt of
             Right (num,"") -> do
-                when (num < minBound @Word8 || num > maxBound @Word8) $
-                        fail "Cosigner number should be between '0' and '255'"
-                pure $ Cosigner num
+                let maxWord = toInteger (maxBound @Word)
+                when (num > maxWord) $
+                        fail "Cosigner number is out of bounds"
+                pure $ Cosigner (fromInteger num)
             _ -> fail "Cosigner should be enumerated with number"
         _ -> fail "Cosigner should be of the form: cosigner#num"
 

--- a/lib/Cardano/Address/Script.hs
+++ b/lib/Cardano/Address/Script.hs
@@ -472,6 +472,7 @@ recommendedValidation = \case
 
     RequireSomeOf m script -> do
         when (m == 0) $ Left MZero
+        when (m > 255) $ Left BigNInRequiredSomeOf
         when (length (omitTimelocks script) < fromIntegral m) $ Left ListTooSmall
         when (hasDuplicate script) $ Left DuplicateSignatures
         when (redundantTimelocks script) $ Left RedundantTimelocks
@@ -577,6 +578,7 @@ data ErrRecommendedValidateScript
     | DuplicateSignatures
     | RedundantTimelocks
     | TimelockTrap
+    | BigNInRequiredSomeOf
     deriving (Eq, Show)
 
 -- | Possible validation errors when validating a script template
@@ -626,6 +628,8 @@ prettyErrValidateScript = \case
         "Some timelocks used are redundant (which is not recommended)."
     NotRecommended TimelockTrap ->
         "The timelocks used are contradictory when used with 'all' (which is not recommended)."
+    NotRecommended BigNInRequiredSomeOf ->
+        "The script requires more than 255 signatures. Such scripts might result in transactions exceeding the possible transaction size limit (which is not recommended)."
 
 -- | Pretty-print a script template validation error.
 --

--- a/lib/Cardano/Address/Script/Parser.hs
+++ b/lib/Cardano/Address/Script/Parser.hs
@@ -34,8 +34,6 @@ import Data.Char
     ( isDigit, isLetter )
 import Data.Text
     ( Text )
-import Data.Word
-    ( Word )
 import Numeric.Natural
     ( Natural )
 import Text.ParserCombinators.ReadP

--- a/lib/Cardano/Address/Script/Parser.hs
+++ b/lib/Cardano/Address/Script/Parser.hs
@@ -35,7 +35,7 @@ import Data.Char
 import Data.Text
     ( Text )
 import Data.Word
-    ( Word8 )
+    ( Word )
 import Numeric.Natural
     ( Natural )
 import Text.ParserCombinators.ReadP
@@ -164,7 +164,7 @@ activeUntilSlotParser = do
     _identifier <- P.string "active_until"
     ActiveUntilSlot <$> slotParser
 
-naturalParser :: ReadP Word8
+naturalParser :: ReadP Word
 naturalParser = do
     P.skipSpaces
     fromInteger . read <$> P.munch1 isDigit

--- a/test/Cardano/Address/ScriptSpec.hs
+++ b/test/Cardano/Address/ScriptSpec.hs
@@ -386,6 +386,10 @@ spec = do
                     ]
             validateScript RecommendedValidation script `shouldBe` Left (NotRecommended RedundantTimelocks)
 
+        it "big N in RequireSomeOf" $ do
+            let script = RequireSomeOf 275 (replicate 300 verKeyHash1)
+            validateScript RecommendedValidation script `shouldBe` Left (NotRecommended BigNInRequiredSomeOf)
+
         it "content in RequireAllOf - 1" $ do
             let script = RequireAllOf [verKeyHash1]
             validateScript RecommendedValidation script `shouldBe` Right ()
@@ -678,6 +682,10 @@ spec = do
                                    ]
                     ]
             validateScriptOfTemplate RecommendedValidation script `shouldBe` Left (NotRecommended RedundantTimelocks)
+
+        it "big N in RequireSomeOf" $ do
+            let script = RequireSomeOf 275 (replicate 300 cosigner0)
+            validateScriptOfTemplate RecommendedValidation script `shouldBe` Left (NotRecommended BigNInRequiredSomeOf)
 
         it "content in RequireAllOf - 1" $ do
             let script = RequireAllOf [cosigner0]

--- a/test/Cardano/Address/ScriptSpec.hs
+++ b/test/Cardano/Address/ScriptSpec.hs
@@ -596,6 +596,13 @@ spec = do
                     ])
             validateScriptTemplate RecommendedValidation scriptTemplate `shouldBe` Left (WrongScript $ NotRecommended RedundantTimelocks)
 
+        it "big cosigner number in script template" $ do
+            let bigCosigner = Cosigner 300
+            let bigCosignerScript = RequireSignatureOf bigCosigner
+            let cosignersBig = Map.singleton bigCosigner (encodeXPubFromTxtUnsafe accXpub0)
+            let scriptTemplate = ScriptTemplate cosignersBig (RequireAllOf [bigCosignerScript])
+            validateScriptTemplate RecommendedValidation scriptTemplate `shouldBe` Left BigCosignerNumber
+
     describe "validateScriptOfTemplate - errors" $ do
         let cosigner0 = RequireSignatureOf (Cosigner 0)
         let cosigner1 = RequireSignatureOf (Cosigner 1)


### PR DESCRIPTION
- Relax N in RequiredSomeOf in Script to accommodate the possible number of participants above 255. Add data constructor `BigNInRequiredSomeOf` to `ErrRecommendedValidateScrip`
- Relax the number of `Cosigner` to accommodate the possible number of participants above 255. Add `BigCosignerNumber` constructor to `ErrValidateScriptTemplate`