### PR TITLE
handle timelock script boundaries in codebase

### DIFF
--- a/lib/Cardano/Address/Script.hs
+++ b/lib/Cardano/Address/Script.hs
@@ -109,6 +109,8 @@ import GHC.Generics
     ( Generic )
 import Numeric.Natural
     ( Natural )
+import Data.Word
+    ( Word64 )
 
 import qualified Cardano.Codec.Bech32.Prefixes as CIP5
 import qualified Cardano.Codec.Cbor as CBOR
@@ -616,7 +618,7 @@ prettyErrValidateScript = \case
         \lists, the verification keys should be bech32-encoded with prefix \
         \'X_vkh', 'X_vk', 'X_xvk' where X is 'addr_shared', 'stake_shared', 'policy', \
         \'drep', 'cc_cold' or 'cc_hot' and timelocks must use non-negative \
-        \numbers as slots."
+        \numbers not exceeding maxBound Word64 as slots."
     NotRecommended EmptyList ->
         "The list inside a script is empty or only contains timelocks \
         \(which is not recommended)."
@@ -781,14 +783,22 @@ parseAtLeast = withObject "Script SomeOf" $ \o -> do
 parseActiveFrom
     :: Value
     -> Parser (Script elem)
-parseActiveFrom = withObject "Script ActiveFrom" $ \o ->
-    ActiveFromSlot <$> o .: "active_from"
+parseActiveFrom = withObject "Script ActiveFrom" $ \o -> do
+    slot <- o .: "active_from"
+    let maxWord64 = fromIntegral (maxBound @Word64)
+    when (slot > maxWord64) $
+        fail "active_from slot exceeds maxBound Word64"
+    pure $ ActiveFromSlot slot
 
 parseActiveUntil
     :: Value
     -> Parser (Script elem)
-parseActiveUntil = withObject "Script ActiveUntil" $ \o ->
-    ActiveUntilSlot <$> o .: "active_until"
+parseActiveUntil = withObject "Script ActiveUntil" $ \o -> do
+    slot <- o .: "active_until"
+    let maxWord64 = fromIntegral (maxBound @Word64)
+    when (slot > maxWord64) $
+        fail "active_until slot exceeds maxBound Word64"
+    pure $ ActiveUntilSlot slot
 
 cosignerToText :: Cosigner -> Text
 cosignerToText (Cosigner ix) = "cosigner#"<> T.pack (show ix)

--- a/lib/Cardano/Address/Script.hs
+++ b/lib/Cardano/Address/Script.hs
@@ -105,12 +105,12 @@ import Data.Text
     ( Text )
 import Data.Traversable
     ( for )
+import Data.Word
+    ( Word64 )
 import GHC.Generics
     ( Generic )
 import Numeric.Natural
     ( Natural )
-import Data.Word
-    ( Word64 )
 
 import qualified Cardano.Codec.Bech32.Prefixes as CIP5
 import qualified Cardano.Codec.Cbor as CBOR

--- a/lib/Cardano/Address/Script/Parser.hs
+++ b/lib/Cardano/Address/Script/Parser.hs
@@ -39,6 +39,8 @@ import Data.Text
     ( Text )
 import Numeric.Natural
     ( Natural )
+import Data.Word
+    ( Word64 )
 import Text.ParserCombinators.ReadP
     ( ReadP, readP_to_S, (<++) )
 
@@ -180,7 +182,11 @@ naturalParser = do
 slotParser :: ReadP Natural
 slotParser = do
     P.skipSpaces
-    fromInteger . read <$> P.munch1 isDigit
+    num <- fromInteger . read <$> P.munch1 isDigit
+    let maxWord64 = fromIntegral (maxBound @Word64)
+    when (num > maxWord64) $
+        fail $ "Slot number exceeds maxBound Word64: " <> show maxWord64
+    pure num
 
 commonPart :: ReadP (Script a) -> ReadP [Script a]
 commonPart parser = do

--- a/lib/Cardano/Address/Script/Parser.hs
+++ b/lib/Cardano/Address/Script/Parser.hs
@@ -37,10 +37,10 @@ import Data.Char
     ( isDigit, isLetter )
 import Data.Text
     ( Text )
-import Numeric.Natural
-    ( Natural )
 import Data.Word
     ( Word64 )
+import Numeric.Natural
+    ( Natural )
 import Text.ParserCombinators.ReadP
     ( ReadP, readP_to_S, (<++) )
 

--- a/test/Cardano/Address/Script/ParserSpec.hs
+++ b/test/Cardano/Address/Script/ParserSpec.hs
@@ -13,7 +13,7 @@ import Prelude
 import Cardano.Address.KeyHash
     ( KeyHash (..), KeyRole (..) )
 import Cardano.Address.Script
-    ( Cosigner (..), Script (..) )
+    ( Cosigner (..), ErrValidateScript (..), Script (..) )
 import Cardano.Address.Script.Parser
     ( requireAllOfParser
     , requireAnyOfParser
@@ -21,6 +21,7 @@ import Cardano.Address.Script.Parser
     , requireCosignerOfParser
     , requireCosignerOfParser
     , requireSignatureOfParser
+    , scriptFromString
     , scriptParser
     )
 import Data.ByteString
@@ -61,6 +62,11 @@ spec = do
     timelockParserTests @KeyHash requireSignatureOfParser
         (kh1,verKeyH1)
     timelockParserTests @Cosigner requireCosignerOfParser
+        (cosigner0,cosigner0Txt)
+
+    slotBoundaryTests @KeyHash requireSignatureOfParser
+        (kh1,verKeyH1)
+    slotBoundaryTests @Cosigner requireCosignerOfParser
         (cosigner0,cosigner0Txt)
   where
     verKeyH1 = "addr_shared_vkh1zxt0uvrza94h3hv4jpv0ttddgnwkvdgeyq8jf9w30mcs6y8w3nq" :: Text
@@ -237,6 +243,50 @@ spec = do
                    , ActiveFromSlot 120
                    , ActiveUntilSlot 125 ]
            valuesParserUnitTest (scriptParser parser) (script16 txt) expected
+
+    slotBoundaryTests
+        :: (Eq a, Show a)
+        => ReadP (Script a)
+        -> (a, Text)
+        -> SpecWith ()
+    slotBoundaryTests parser (obj,txt) = do
+       describe "active_from maxBound Word64 accepted" $ do
+           let maxWord64 = "18446744073709551615"
+           let expected = RequireAllOf
+                   [ RequireSignatureOf obj
+                   , ActiveFromSlot 18446744073709551615 ]
+           valuesParserUnitTest (scriptParser parser) ("all ["<>txt<>", active_from "<>maxWord64<>"]") expected
+
+       describe "active_from maxBound Word64 + 1 rejected" $ do
+           let tooBig = "18446744073709551616"
+           let inp = "all ["<>txt<>", active_from "<>tooBig<>"]"
+           it ("input=" <> show inp) $
+               scriptFromString (scriptParser parser) (T.unpack inp) `shouldBe` Left Malformed
+
+       describe "active_until maxBound Word64 accepted" $ do
+           let maxWord64 = "18446744073709551615"
+           let expected = RequireAllOf
+                   [ RequireSignatureOf obj
+                   , ActiveUntilSlot 18446744073709551615 ]
+           valuesParserUnitTest (scriptParser parser) ("all ["<>txt<>", active_until "<>maxWord64<>"]") expected
+
+       describe "active_until maxBound Word64 + 1 rejected" $ do
+           let tooBig = "18446744073709551616"
+           let inp = "all ["<>txt<>", active_until "<>tooBig<>"]"
+           it ("input=" <> show inp) $
+               scriptFromString (scriptParser parser) (T.unpack inp) `shouldBe` Left Malformed
+
+       describe "active_from maxBound Word64 + 2 rejected" $ do
+           let tooBig = "18446744073709551617"
+           let inp = "all ["<>txt<>", active_from "<>tooBig<>"]"
+           it ("input=" <> show inp) $
+               scriptFromString (scriptParser parser) (T.unpack inp) `shouldBe` Left Malformed
+
+       describe "active_until maxBound Word64 + 2 rejected" $ do
+           let tooBig = "18446744073709551617"
+           let inp = "all ["<>txt<>", active_until "<>tooBig<>"]"
+           it ("input=" <> show inp) $
+               scriptFromString (scriptParser parser) (T.unpack inp) `shouldBe` Left Malformed
 
 valuesParserUnitTest
     :: (Eq s, Show s)

--- a/test/Cardano/Address/ScriptSpec.hs
+++ b/test/Cardano/Address/ScriptSpec.hs
@@ -61,6 +61,8 @@ import Data.Maybe
     ( fromJust )
 import Data.Text
     ( Text )
+import Numeric.Natural
+    ( Natural )
 import Test.Arbitrary
     ()
 import Test.Hspec
@@ -81,6 +83,8 @@ import Test.QuickCheck
     , vectorOf
     , (===)
     )
+import Data.Word
+    ( Word64 )
 
 import qualified Cardano.Address.Style.Shared as Shared
 import qualified Cardano.Address.Style.Shelley as Shelley
@@ -736,6 +740,41 @@ spec = do
     describe "can perform text roundtrip - Script Cosigner" $
         it "scriptFromString . T.unpack . scriptToText === pure" $ property prop_scriptTextRoundtrip
 
+    describe "timelock slot boundary tests" $ do
+        let maxWord64 = 18446744073709551615 :: Natural
+        it "JSON active_from maxBound Word64 accepted" $ do
+            let json = "{\"active_from\": " <> T.pack (show maxWord64) <> "}"
+            Json.eitherDecodeStrict @(Script KeyHash) (T.encodeUtf8 json)
+                `shouldBe` Right (ActiveFromSlot maxWord64)
+
+        it "JSON active_from maxBound Word64 + 1 rejected" $ do
+            let json = "{\"active_from\": 18446744073709551616}"
+            case Json.eitherDecodeStrict @(Script KeyHash) (T.encodeUtf8 json) of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "Expected JSON parse failure"
+
+        it "JSON active_until maxBound Word64 accepted" $ do
+            let json = "{\"active_until\": " <> T.pack (show maxWord64) <> "}"
+            Json.eitherDecodeStrict @(Script KeyHash) (T.encodeUtf8 json)
+                `shouldBe` Right (ActiveUntilSlot maxWord64)
+
+        it "JSON active_until maxBound Word64 + 1 rejected" $ do
+            let json = "{\"active_until\": 18446744073709551616}"
+            case Json.eitherDecodeStrict @(Script KeyHash) (T.encodeUtf8 json) of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "Expected JSON parse failure"
+
+        it "JSON active_from maxBound Word64 + 2 rejected" $ do
+            let json = "{\"active_from\": 18446744073709551617}"
+            case Json.eitherDecodeStrict @(Script KeyHash) (T.encodeUtf8 json) of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "Expected JSON parse failure"
+
+        it "JSON active_until maxBound Word64 + 2 rejected" $ do
+            let json = "{\"active_until\": 18446744073709551617}"
+            case Json.eitherDecodeStrict @(Script KeyHash) (T.encodeUtf8 json) of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "Expected JSON parse failure"
 
     describe "some JSON parsing error" $ do
         it "Invalid type" $ do
@@ -799,10 +838,11 @@ instance Arbitrary (Script Cosigner) where
 genScript :: Gen (Script elem) -> Gen (Script elem)
 genScript elemGen = scale (`div` 3) $ sized scriptTree
     where
+        genSlot = fromIntegral <$> arbitrary @Word64
         scriptTree 0 = oneof
             [ elemGen
-            , ActiveFromSlot <$> arbitrary
-            , ActiveUntilSlot <$> arbitrary
+            , ActiveFromSlot <$> genSlot
+            , ActiveUntilSlot <$> genSlot
             ]
         scriptTree n = do
             Positive m <- arbitrary

--- a/test/Cardano/Address/ScriptSpec.hs
+++ b/test/Cardano/Address/ScriptSpec.hs
@@ -61,6 +61,8 @@ import Data.Maybe
     ( fromJust )
 import Data.Text
     ( Text )
+import Data.Word
+    ( Word64 )
 import Numeric.Natural
     ( Natural )
 import Test.Arbitrary
@@ -83,8 +85,6 @@ import Test.QuickCheck
     , vectorOf
     , (===)
     )
-import Data.Word
-    ( Word64 )
 
 import qualified Cardano.Address.Style.Shared as Shared
 import qualified Cardano.Address.Style.Shelley as Shelley


### PR DESCRIPTION
Untrusted native-script text or JSON containing active_from/active_until slots larger than maxBound Word64 are now rejected at the parser boundary. This prevents the truncation bug where such values were silently converted via CBOR.encodeWord64 (fromInteger $ toInteger slotNum), causing script hashes, preimages, addresses, and governance credentials to be generated for a materially different timelock than the one shown to the user.